### PR TITLE
Build failed due to client-server rendering error

### DIFF
--- a/app/reading/page.tsx
+++ b/app/reading/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import Interpretation from "@/components/reading/interpretation"
 import QuestionStep from "@/components/reading/question"
 import ReadingType from "@/components/reading/reading-type"


### PR DESCRIPTION
Add 'use client' directive to `/reading/page.tsx` to resolve a Next.js build error during static generation.

The `/reading/page.tsx` was attempting to render components that utilized the `useTarot()` client-side hook within a server component context. This led to an error during prerendering, as client hooks cannot be invoked on the server. Marking the page as a client component allows these client-side dependencies to be correctly handled.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7b719d8-056b-4901-94a6-58a2f1bf418e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7b719d8-056b-4901-94a6-58a2f1bf418e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

