### PR TITLE
Hide nav items on mobile

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
     return (
         <footer className='w-full z-10'>
             <div className='max-w-6xl mx-auto px-6 pt-4 pb-12 md:pb-6'>
-                <div className='flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0'>
+                <div className='flex flex-row justify-between items-center'>
                     <button
                         type='button'
                         onClick={handleBrandClick}
@@ -24,8 +24,8 @@ export default function Footer() {
                             Asking Fate
                         </span>
                     </button>
-                    <div className='flex flex-col md:flex-row items-center space-y-2 md:space-y-0 md:space-x-6'>
-                        <div className='grid grid-cols-2 md:flex md:space-x-6 gap-4 md:gap-0 text-sm text-muted-foreground text-center md:text-left'>
+                    <div className='flex flex-row items-center space-x-6'>
+                        <div className='flex space-x-6 text-sm text-muted-foreground'>
                             <Link
                                 href='/privacy-policy'
                                 className='hover:text-foreground transition-colors'
@@ -39,7 +39,7 @@ export default function Footer() {
                                 Terms of Service
                             </Link>
                         </div>
-                        <div className='text-xs text-muted-foreground text-center md:text-right'>
+                        <div className='text-xs text-muted-foreground'>
                             © 2025 Asking Fate. All rights reserved.
                         </div>
                     </div>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
     return (
         <footer className='w-full z-10'>
             <div className='max-w-6xl mx-auto px-6 pt-4 pb-12 md:pb-6'>
-                <div className='flex flex-row justify-between items-center'>
+                <div className='flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0'>
                     <button
                         type='button'
                         onClick={handleBrandClick}
@@ -24,7 +24,7 @@ export default function Footer() {
                             Asking Fate
                         </span>
                     </button>
-                    <div className='flex flex-row items-center space-x-6'>
+                    <div className='flex flex-col md:flex-row items-center space-y-2 md:space-y-0 md:space-x-6'>
                         <div className='flex space-x-6 text-sm text-muted-foreground'>
                             <Link
                                 href='/privacy-policy'
@@ -39,7 +39,7 @@ export default function Footer() {
                                 Terms of Service
                             </Link>
                         </div>
-                        <div className='text-xs text-muted-foreground'>
+                        <div className='text-xs text-muted-foreground text-center md:text-right'>
                             © 2025 Asking Fate. All rights reserved.
                         </div>
                     </div>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -25,7 +25,7 @@ export default function Footer() {
                         </span>
                     </button>
                     <div className='flex flex-col md:flex-row items-center space-y-2 md:space-y-0 md:space-x-6'>
-                        <div className='flex space-x-6 text-sm text-muted-foreground'>
+                        <div className='hidden md:flex space-x-6 text-sm text-muted-foreground'>
                             <Link
                                 href='/privacy-policy'
                                 className='hover:text-foreground transition-colors'

--- a/components/navbar/index.tsx
+++ b/components/navbar/index.tsx
@@ -68,6 +68,24 @@ export function Navbar() {
                         >
                             About
                         </Link>
+                        {/* Mobile: Sign In button */}
+                        <div className='md:hidden'>
+                            {!loading && user ? (
+                                <UserProfile variant='mobile' />
+                            ) : (
+                                <Link href='/signin'>
+                                    <Button
+                                        variant='outline'
+                                        size='sm'
+                                        className='flex items-center justify-center gap-2 px-4 py-2 rounded-full bg-white/10 text-white/90 border border-white/10 hover:bg-white/15 transition'
+                                    >
+                                        <LogIn className='w-4 h-4' />
+                                        Sign In
+                                    </Button>
+                                </Link>
+                            )}
+                        </div>
+
                         <Sheet
                             open={mysticalOpen}
                             onOpenChange={setMysticalOpen}

--- a/components/navbar/index.tsx
+++ b/components/navbar/index.tsx
@@ -68,24 +68,6 @@ export function Navbar() {
                         >
                             About
                         </Link>
-                        {/* Mobile: Sign In button */}
-                        <div className='md:hidden'>
-                            {!loading && user ? (
-                                <UserProfile variant='mobile' />
-                            ) : (
-                                <Link href='/signin'>
-                                    <Button
-                                        variant='outline'
-                                        size='sm'
-                                        className='flex items-center justify-center gap-2 px-4 py-2 rounded-full bg-white/10 text-white/90 border border-white/10 hover:bg-white/15 transition'
-                                    >
-                                        <LogIn className='w-4 h-4' />
-                                        Sign In
-                                    </Button>
-                                </Link>
-                            )}
-                        </div>
-
                         <Sheet
                             open={mysticalOpen}
                             onOpenChange={setMysticalOpen}
@@ -150,6 +132,24 @@ export function Navbar() {
                                 </div>
                             </SheetContent>
                         </Sheet>
+
+                        {/* Mobile: Sign In button */}
+                        <div className='md:hidden'>
+                            {!loading && user ? (
+                                <UserProfile variant='mobile' />
+                            ) : (
+                                <Link href='/signin'>
+                                    <Button
+                                        variant='outline'
+                                        size='sm'
+                                        className='flex items-center justify-center gap-2 px-4 py-2 rounded-full bg-white/10 text-white/90 border border-white/10 hover:bg-white/15 transition'
+                                    >
+                                        <LogIn className='w-4 h-4' />
+                                        Sign In
+                                    </Button>
+                                </Link>
+                            )}
+                        </div>
 
                         {/* Desktop only: User Profile / Sign In button */}
                         <div className='hidden md:block'>

--- a/components/navbar/index.tsx
+++ b/components/navbar/index.tsx
@@ -58,13 +58,13 @@ export function Navbar() {
                     <div className='flex items-center space-x-6'>
                         <Link
                             href='/'
-                            className='text-cosmic-light hover:text-white transition-colors'
+                            className='hidden md:block text-cosmic-light hover:text-white transition-colors'
                         >
                             Home
                         </Link>
                         <Link
                             href='/about'
-                            className='text-cosmic-light hover:text-white transition-colors'
+                            className='hidden md:block text-cosmic-light hover:text-white transition-colors'
                         >
                             About
                         </Link>

--- a/components/navbar/sidebar-sheet.tsx
+++ b/components/navbar/sidebar-sheet.tsx
@@ -48,6 +48,9 @@ export function SidebarSheet({ open, onOpenChange }: SidebarSheetProps) {
     const sidebarLinks = [
         { href: "/", label: "Home", Icon: Home },
         { href: "/about", label: "About", Icon: Info },
+    ] as const
+
+    const legalLinks = [
         { href: "/privacy-policy", label: "Privacy Policy", Icon: Shield },
         { href: "/terms-of-service", label: "Terms of Service", Icon: FileText },
     ] as const
@@ -169,6 +172,20 @@ export function SidebarSheet({ open, onOpenChange }: SidebarSheetProps) {
                                 </ul>
                             )}
                         </li>
+
+                        {/* Legal Links */}
+                        {legalLinks.map(({ href, label, Icon }) => (
+                            <li key={href}>
+                                <Link
+                                    href={href}
+                                    className='flex items-center gap-2 px-3 py-2 rounded-md text-cosmic-light hover:text-white hover:bg-white/10 transition-colors'
+                                    onClick={() => onOpenChange(false)}
+                                >
+                                    <Icon className='w-4 h-4' />
+                                    <span>{label}</span>
+                                </Link>
+                            </li>
+                        ))}
                     </ul>
                 </nav>
             </SheetContent>

--- a/components/navbar/sidebar-sheet.tsx
+++ b/components/navbar/sidebar-sheet.tsx
@@ -7,7 +7,8 @@ import {
     ChevronDown,
     ChevronUp,
     Sparkles,
-    LogIn,
+    Shield,
+    FileText,
 } from "lucide-react"
 import { useState } from "react"
 import {
@@ -47,6 +48,8 @@ export function SidebarSheet({ open, onOpenChange }: SidebarSheetProps) {
     const sidebarLinks = [
         { href: "/", label: "Home", Icon: Home },
         { href: "/about", label: "About", Icon: Info },
+        { href: "/privacy-policy", label: "Privacy Policy", Icon: Shield },
+        { href: "/terms-of-service", label: "Terms of Service", Icon: FileText },
     ] as const
 
     return (
@@ -75,9 +78,9 @@ export function SidebarSheet({ open, onOpenChange }: SidebarSheetProps) {
                 </SheetHeader>
                 <nav>
                     <ul className='flex flex-col space-y-1 p-1'>
-                        {/* Sign In / User Profile at the top */}
-                        <li className='pb-2 border-b border-white/10 mb-2'>
-                            {!loading && user ? (
+                        {/* User Profile at the top (only if logged in) */}
+                        {!loading && user && (
+                            <li className='pb-2 border-b border-white/10 mb-2'>
                                 <UserProfileDropdown
                                     onClose={() => onOpenChange(false)}
                                 >
@@ -101,17 +104,8 @@ export function SidebarSheet({ open, onOpenChange }: SidebarSheetProps) {
                                         </div>
                                     </div>
                                 </UserProfileDropdown>
-                            ) : (
-                                <Link
-                                    href='/signin'
-                                    className='flex items-center justify-center gap-2 px-4 py-2.5 rounded-full bg-white/10 text-white/90 border border-white/10 hover:bg-white/15 transition'
-                                    onClick={() => onOpenChange(false)}
-                                >
-                                    <LogIn className='w-4 h-4' />
-                                    <span>Sign In</span>
-                                </Link>
-                            )}
-                        </li>
+                            </li>
+                        )}
 
                         {sidebarLinks.map(({ href, label, Icon }) => (
                             <li key={href}>


### PR DESCRIPTION
Hide Home and About links in the navbar on mobile devices, keeping them visible on larger screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-daa7a7c2-baa9-4292-8a8e-61bd1a488364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-daa7a7c2-baa9-4292-8a8e-61bd1a488364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

