### PR TITLE
Pause autoplay for prompt card interaction

### DIFF
--- a/components/reading/card-selection/index.tsx
+++ b/components/reading/card-selection/index.tsx
@@ -1,13 +1,11 @@
 "use client"
 import { TarotCard, useTarot } from "@/contexts/tarot-context"
-import { Button } from "../../ui/button"
 import { Card } from "../../ui/card"
 import { Badge } from "../../ui/badge"
-import { Pencil } from "lucide-react"
 import { ReadingConfig } from "../../../app/reading/page"
 import { CircularCardSpread } from "./circular-card-spread"
-import { useRouter } from "next/navigation"
-import { isFollowUpQuestion, getCleanQuestionText } from "@/lib/question-utils"
+import { isFollowUpQuestion } from "@/lib/question-utils"
+import EditableQuestion from "../editable-question"
 
 export default function CardSelection({
     readingConfig,
@@ -18,15 +16,10 @@ export default function CardSelection({
         currentStep,
         setCurrentStep,
         question,
+        setQuestion,
         readingType,
         setSelectedCards,
     } = useTarot()
-    const router = useRouter()
-
-    const handleEditQuestion = () => {
-        // Navigate to homepage - the question is already in context
-        router.push("/")
-    }
 
     const handleBackToReadingType = () => {
         setCurrentStep("reading-type")
@@ -55,46 +48,28 @@ export default function CardSelection({
             {currentStep === "card-selection" && (
                 <div className='space-y-8 animate-fade-in'>
                     <Card className='px-6 pt-12 border-0'>
-                        <div className='text-center space-y-2'>
-                            <div className='flex items-center justify-center gap-2 relative'>
-                                <h2 className='font-serif font-semibold text-xl relative'>
-                                    {isFollowUpQuestion(question) && (
-                                        <Badge
-                                            variant='secondary'
-                                            className='absolute -top-6 -left-8 -rotate-12 bg-primary/20 text-white border-white/30'
-                                        >
-                                            Follow up
-                                        </Badge>
-                                    )}
-                                    Question
-                                </h2>
-                                <Button
-                                    onClick={handleEditQuestion}
-                                    variant='ghost'
-                                    size='sm'
-                                    className='h-8 w-8 p-0 hover:bg-primary/10'
+                        <div className='space-y-4'>
+                            <EditableQuestion
+                                question={question}
+                                onQuestionChange={setQuestion}
+                            />
+                            <div className='flex justify-center'>
+                                <Badge
+                                    className={`text-sm text-primary bg-transparent border-primary/50 ${
+                                        isFollowUpQuestion(question)
+                                            ? "cursor-default"
+                                            : "cursor-pointer hover:bg-primary/10 transition-colors"
+                                    }`}
+                                    onClick={
+                                        isFollowUpQuestion(question)
+                                            ? undefined
+                                            : handleBackToReadingType
+                                    }
                                 >
-                                    <Pencil className='h-4 w-4 text-muted-foreground hover:text-primary' />
-                                </Button>
+                                    {readingType &&
+                                        readingConfig[readingType].title}
+                                </Badge>
                             </div>
-                            <p className='text-muted-foreground italic'>
-                                &ldquo;{getCleanQuestionText(question)}&rdquo;
-                            </p>
-                            <Badge
-                                className={`text-sm text-primary bg-transparent border-primary/50 ${
-                                    isFollowUpQuestion(question)
-                                        ? "cursor-default"
-                                        : "cursor-pointer hover:bg-primary/10 transition-colors"
-                                }`}
-                                onClick={
-                                    isFollowUpQuestion(question)
-                                        ? undefined
-                                        : handleBackToReadingType
-                                }
-                            >
-                                {readingType &&
-                                    readingConfig[readingType].title}
-                            </Badge>
                         </div>
                     </Card>
 

--- a/components/reading/editable-question.tsx
+++ b/components/reading/editable-question.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import { Pencil, Check, X } from "lucide-react"
+import { Button } from "../ui/button"
+import { Input } from "../ui/input"
+import { Badge } from "../ui/badge"
+import { isFollowUpQuestion, getCleanQuestionText } from "@/lib/question-utils"
+
+interface EditableQuestionProps {
+    question: string
+    onQuestionChange: (newQuestion: string) => void
+    showFollowUpBadge?: boolean
+    className?: string
+}
+
+export default function EditableQuestion({
+    question,
+    onQuestionChange,
+    showFollowUpBadge = true,
+    className = "",
+}: EditableQuestionProps) {
+    const [isEditing, setIsEditing] = useState(false)
+    const [editValue, setEditValue] = useState(question)
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    // Focus input when editing starts
+    useEffect(() => {
+        if (isEditing && inputRef.current) {
+            inputRef.current.focus()
+            inputRef.current.select()
+        }
+    }, [isEditing])
+
+    const handleEdit = () => {
+        setEditValue(question)
+        setIsEditing(true)
+    }
+
+    const handleSave = () => {
+        if (editValue.trim() && editValue.trim() !== question) {
+            onQuestionChange(editValue.trim())
+        }
+        setIsEditing(false)
+    }
+
+    const handleCancel = () => {
+        setEditValue(question)
+        setIsEditing(false)
+    }
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === "Enter") {
+            handleSave()
+        } else if (e.key === "Escape") {
+            handleCancel()
+        }
+    }
+
+    return (
+        <div className={`text-center space-y-2 ${className}`}>
+            <div className='flex items-center justify-center gap-2 relative'>
+                <h2 className='font-serif font-semibold text-xl relative'>
+                    {showFollowUpBadge && isFollowUpQuestion(question) && (
+                        <Badge
+                            variant='secondary'
+                            className='absolute -top-6 -left-8 -rotate-12 bg-primary/20 text-white border-white/30'
+                        >
+                            Follow up
+                        </Badge>
+                    )}
+                    Question
+                </h2>
+                <Button
+                    onClick={handleEdit}
+                    variant='ghost'
+                    size='sm'
+                    className='h-8 w-8 p-0 hover:bg-primary/10'
+                >
+                    <Pencil className='h-4 w-4 text-muted-foreground hover:text-primary' />
+                </Button>
+            </div>
+
+            {isEditing ? (
+                <div className='space-y-2'>
+                    <Input
+                        ref={inputRef}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        className='text-center text-muted-foreground italic border-primary/50 focus:border-primary'
+                        placeholder='Enter your question...'
+                    />
+                    <div className='flex items-center justify-center gap-2'>
+                        <Button
+                            onClick={handleSave}
+                            size='sm'
+                            className='h-8 px-3 bg-primary hover:bg-primary/90'
+                        >
+                            <Check className='h-3 w-3 mr-1' />
+                            Save
+                        </Button>
+                        <Button
+                            onClick={handleCancel}
+                            size='sm'
+                            variant='outline'
+                            className='h-8 px-3'
+                        >
+                            <X className='h-3 w-3 mr-1' />
+                            Cancel
+                        </Button>
+                    </div>
+                </div>
+            ) : (
+                <p className='text-muted-foreground italic'>
+                    &ldquo;{getCleanQuestionText(question)}&rdquo;
+                </p>
+            )}
+        </div>
+    )
+}

--- a/components/reading/reading-type.tsx
+++ b/components/reading/reading-type.tsx
@@ -1,13 +1,11 @@
 "use client"
-import { Pencil } from "lucide-react"
-import { Button } from "../ui/button"
 import { Card } from "../ui/card"
 import { Badge } from "../ui/badge"
 import { useTarot } from "@/contexts/tarot-context"
 import { ReadingConfig } from "../../app/reading/page"
-import { useRouter } from "next/navigation"
-import { isFollowUpQuestion, getCleanQuestionText } from "@/lib/question-utils"
+import { isFollowUpQuestion } from "@/lib/question-utils"
 import { useEffect } from "react"
+import EditableQuestion from "./editable-question"
 
 export default function ReadingType({
     readingConfig,
@@ -18,15 +16,10 @@ export default function ReadingType({
         currentStep,
         setCurrentStep,
         question,
+        setQuestion,
         readingType,
         setReadingType,
     } = useTarot()
-    const router = useRouter()
-
-    const handleEditQuestion = () => {
-        // Navigate to homepage - the question is already in context
-        router.push("/")
-    }
 
     const handleReadingTypeSelect = (
         type: "simple" | "intermediate" | "advanced"
@@ -46,33 +39,10 @@ export default function ReadingType({
             {currentStep === "reading-type" && (
                 <div className='space-y-8 animate-fade-in'>
                     <Card className='px-6 pt-12 pb-6 border-0'>
-                        <div className='text-center space-y-2'>
-                            <div className='flex items-center justify-center gap-2 relative'>
-                                <h2 className='font-serif font-semibold text-xl relative'>
-                                    {isFollowUpQuestion(question) && (
-                                        <Badge
-                                            variant='secondary'
-                                            className='absolute -top-6 -left-8 -rotate-12 bg-primary/20 text-white border-white/30'
-                                        >
-                                            Follow up
-                                        </Badge>
-                                    )}
-                                    Question
-                                </h2>
-                                <Button
-                                    onClick={handleEditQuestion}
-                                    variant='ghost'
-                                    size='sm'
-                                    className='h-8 w-8 p-0 hover:bg-primary/10'
-                                >
-                                    <Pencil className='h-4 w-4 text-muted-foreground hover:text-primary' />
-                                </Button>
-                            </div>
-
-                            <p className='text-muted-foreground italic'>
-                                &ldquo;{getCleanQuestionText(question)}&rdquo;
-                            </p>
-                        </div>
+                        <EditableQuestion
+                            question={question}
+                            onQuestionChange={setQuestion}
+                        />
                     </Card>
 
                     {isFollowUpQuestion(question) ? (

--- a/components/suggestion-prompt-card.tsx
+++ b/components/suggestion-prompt-card.tsx
@@ -194,9 +194,9 @@ export default function SuggestionPromptCard({
         onSuggestionClick(suggestion)
     }
 
-    const handleSlideChange = useCallback(() => {
+    const handleUserInteraction = useCallback(() => {
         if (swiperRef.current) {
-            // Stop autoplay immediately when user manually slides
+            // Stop autoplay immediately when user interacts
             swiperRef.current.autoplay.stop()
             
             // Clear any existing timeout
@@ -305,7 +305,10 @@ export default function SuggestionPromptCard({
                         onSwiper={(swiper) => {
                             swiperRef.current = swiper
                         }}
-                        onSlideChange={handleSlideChange}
+                        onTouchStart={handleUserInteraction}
+                        onTouchMove={handleUserInteraction}
+                        onMouseDown={handleUserInteraction}
+                        onSliderMove={handleUserInteraction}
                         modules={[Autoplay, FreeMode]}
                         spaceBetween={12}
                         slidesPerView='auto'

--- a/components/suggestion-prompt-card.tsx
+++ b/components/suggestion-prompt-card.tsx
@@ -188,7 +188,7 @@ export default function SuggestionPromptCard({
     const [selectedCategory, setSelectedCategory] = useState<Category>(
         categories[0]
     )
-    const [showPrompts, setShowPrompts] = useState(true)
+    const [showPrompts, setShowPrompts] = useState(false)
 
     const handleSuggestionClick = (suggestion: string) => {
         onSuggestionClick(suggestion)


### PR DESCRIPTION
Implement a 3-second pause for Swiper autoplay after a manual slide to allow users to focus on prompt cards.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e675783-99c8-4f53-9c3f-ee40e43eaa77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e675783-99c8-4f53-9c3f-ee40e43eaa77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

