### PR TITLE
Update spreading type selection and drag interaction

### DIFF
--- a/app/[locale]/signup/page.tsx
+++ b/app/[locale]/signup/page.tsx
@@ -10,8 +10,6 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Link } from "@/i18n/navigation"
-import { GoogleSignInButton } from "@/components/auth/google-signin-button"
-import { AuthDivider } from "@/components/auth/auth-divider"
 import { useAuth } from "@/hooks/use-auth"
 import { useTranslations } from "next-intl"
 

--- a/components/reading/card-selection/index.tsx
+++ b/components/reading/card-selection/index.tsx
@@ -25,7 +25,6 @@ export default function CardSelection({
         question,
         readingType,
         setSelectedCards,
-        setInterpretation,
         clearInterpretationState,
         isFollowUp,
         followUpQuestion,

--- a/components/reading/card-selection/index.tsx
+++ b/components/reading/card-selection/index.tsx
@@ -1,4 +1,5 @@
 "use client"
+import React, { useMemo, useState } from "react"
 import { TarotCard, useTarot } from "@/contexts/tarot-context"
 import { Button } from "../../ui/button"
 import { Card } from "../../ui/card"
@@ -6,6 +7,8 @@ import { Badge } from "../../ui/badge"
 import { Pencil } from "lucide-react"
 import { ReadingConfig } from "../../../app/[locale]/reading/page"
 import { CircularCardSpread } from "./circular-card-spread"
+import LinearCardSpread from "./linear-card-spread"
+import { useIsMobile } from "@/hooks/use-mobile"
 import { useRouter } from "next/navigation"
 import { getCleanQuestionText } from "@/lib/question-utils"
 import { useTranslations } from "next-intl"
@@ -28,6 +31,14 @@ export default function CardSelection({
         followUpQuestion,
     } = useTarot()
     const router = useRouter()
+    const isMobile = useIsMobile()
+
+    // Desktop-only spread mode selection; mobile is forced to linear
+    const [spreadMode, setSpreadMode] = useState<"circular" | "linear">("circular")
+
+    // Aggregated selection for dual circular spreads
+    const [aggSelected, setAggSelected] = useState<{ name: string; isReversed: boolean }[]>([])
+    const cardsToSelect = readingType ? readingConfig[readingType].cards : 1
 
     const handleEditQuestion = () => {
         // Navigate to homepage - the question is already in context
@@ -58,6 +69,32 @@ export default function CardSelection({
 
         setSelectedCards(tarotCards)
         setCurrentStep("interpretation")
+    }
+
+    const externalNames = useMemo(
+        () => aggSelected.map((c) => c.name),
+        [aggSelected]
+    )
+
+    const handlePartialSelect = (
+        card: { name: string; isReversed: boolean },
+        action: "add" | "remove"
+    ) => {
+        setAggSelected((prev) => {
+            let next = prev
+            if (action === "add") {
+                if (!prev.find((c) => c.name === card.name)) {
+                    next = [...prev, card]
+                }
+            } else {
+                next = prev.filter((c) => c.name !== card.name)
+            }
+            if (next.length === cardsToSelect) {
+                // finalize automatically
+                handleCardsSelected(next)
+            }
+            return next
+        })
     }
     return (
         <>
@@ -124,10 +161,52 @@ export default function CardSelection({
                         </div>
 
                         {readingType && (
-                            <CircularCardSpread
-                                cardsToSelect={readingConfig[readingType].cards}
-                                onCardsSelected={handleCardsSelected}
-                            />
+                            <>
+                                {/* Spread type selector - desktop only */}
+                                {!isMobile && (
+                                    <div className='flex items-center justify-center gap-2'>
+                                        <Button
+                                            variant={spreadMode === "circular" ? "default" : "outline"}
+                                            onClick={() => setSpreadMode("circular")}
+                                            className='rounded-full'
+                                        >
+                                            {t("chooseCards.circular", { default: "Circular" })}
+                                        </Button>
+                                        <Button
+                                            variant={spreadMode === "linear" ? "default" : "outline"}
+                                            onClick={() => setSpreadMode("linear")}
+                                            className='rounded-full'
+                                        >
+                                            {t("chooseCards.linear", { default: "Linear" })}
+                                        </Button>
+                                    </div>
+                                )}
+
+                                {/* Mobile: force linear */}
+                                {isMobile || spreadMode === "linear" ? (
+                                    <LinearCardSpread
+                                        cardsToSelect={readingConfig[readingType].cards}
+                                        onCardsSelected={handleCardsSelected}
+                                    />
+                                ) : (
+                                    <div className='grid grid-cols-1 lg:grid-cols-2 gap-6'>
+                                        <CircularCardSpread
+                                            deferFinalization
+                                            cardsToSelect={readingConfig[readingType].cards}
+                                            onCardsSelected={handleCardsSelected}
+                                            onPartialSelect={(c, action) => handlePartialSelect(c, action)}
+                                            externalSelectedNames={externalNames}
+                                        />
+                                        <CircularCardSpread
+                                            deferFinalization
+                                            cardsToSelect={readingConfig[readingType].cards}
+                                            onCardsSelected={handleCardsSelected}
+                                            onPartialSelect={(c, action) => handlePartialSelect(c, action)}
+                                            externalSelectedNames={externalNames}
+                                        />
+                                    </div>
+                                )}
+                            </>
                         )}
                     </div>
                 </div>

--- a/components/reading/card-selection/linear-card-spread.tsx
+++ b/components/reading/card-selection/linear-card-spread.tsx
@@ -190,7 +190,7 @@ export function LinearCardSpread({
                         <SwiperSlide key={`${name}-${idx}`} className='!w-28'>
                             <div className='flex items-center justify-center h-[320px]'>
                                 <div
-                                    className={`w-24 h-36 rounded-[14px] border-2 border-blue-900 bg-white p-[3px] shadow-2xl select-none touch-none ${
+                                    className={`w-24 h-36 rounded-[16px] bg-gradient-to-br from-[#15a6ff] via-[#b56cff] to-[#15a6ff] p-[2px] shadow-2xl select-none touch-none ${
                                         disabled ? "pointer-events-none" : ""
                                     }`}
                                     onMouseDown={(e: React.MouseEvent<HTMLDivElement>) =>
@@ -211,14 +211,25 @@ export function LinearCardSpread({
                                     role='button'
                                     aria-label='Swipe up to select card'
                                 >
-                                    <div className='relative w-full h-full rounded-[10px] bg-gradient-to-br from-[#0a1a3a] to-[#3b0f4a] border border-white/10 shadow-inner flex items-center justify-center'>
-                                        <div className='absolute inset-0 rounded-[10px] pointer-events-none'
+                                    <div className='w-full h-full rounded-[14px] bg-white p-[3px]'>
+                                        <div
+                                            className='relative w-full h-full rounded-[12px] overflow-hidden border border-white/10 shadow-[inset_0_0_30px_rgba(0,0,0,0.6)]'
                                             style={{
                                                 background:
-                                                    "radial-gradient(circle at 30% 20%, rgba(255,255,255,0.08), transparent 40%), radial-gradient(circle at 70% 80%, rgba(255,255,255,0.06), transparent 45%)",
+                                                    "linear-gradient(135deg, #05081a, #1a0b2e 60%, #3b0f4a), radial-gradient(circle at 30% 20%, #7b2cbf 0%, transparent 40%), radial-gradient(circle at 70% 80%, #00bcd4 0%, transparent 45%)",
                                             }}
-                                        />
-                                        <div className='text-amber-300 text-xl'>✷</div>
+                                        >
+                                            <div
+                                                className='absolute inset-0 pointer-events-none'
+                                                style={{
+                                                    background:
+                                                        "radial-gradient(1px 1px at 20% 30%, #ffffff 99%, transparent 100%), radial-gradient(1px 1px at 80% 60%, #ffffff 99%, transparent 100%), radial-gradient(1px 1px at 40% 80%, #ffffff 99%, transparent 100%), radial-gradient(1px 1px at 60% 20%, #ffffff 99%, transparent 100%), radial-gradient(1px 1px at 75% 25%, #ffffff 99%, transparent 100%)",
+                                                }}
+                                            />
+                                            <div className='relative flex items-center justify-center h-full'>
+                                                <div className='text-amber-300 text-xl'>✷</div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/components/reading/card-selection/linear-card-spread.tsx
+++ b/components/reading/card-selection/linear-card-spread.tsx
@@ -1,0 +1,258 @@
+"use client"
+
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import { useTranslations } from "next-intl"
+
+type BasicCard = {
+    name: string
+    isReversed: boolean
+}
+
+const TAROT_DECK: string[] = [
+    "The Fool",
+    "The Magician",
+    "The High Priestess",
+    "The Empress",
+    "The Emperor",
+    "The Hierophant",
+    "The Lovers",
+    "The Chariot",
+    "Strength",
+    "The Hermit",
+    "Wheel of Fortune",
+    "Justice",
+    "The Hanged Man",
+    "Death",
+    "Temperance",
+    "The Devil",
+    "The Tower",
+    "The Star",
+    "The Moon",
+    "The Sun",
+    "Judgement",
+    "The World",
+    "Ace of Cups",
+    "Two of Cups",
+    "Three of Cups",
+    "Four of Cups",
+    "Five of Cups",
+    "Six of Cups",
+    "Seven of Cups",
+    "Eight of Cups",
+    "Nine of Cups",
+    "Ten of Cups",
+    "Page of Cups",
+    "Knight of Cups",
+    "Queen of Cups",
+    "King of Cups",
+    "Ace of Swords",
+    "Two of Swords",
+    "Three of Swords",
+    "Four of Swords",
+    "Five of Swords",
+    "Six of Swords",
+    "Seven of Swords",
+    "Eight of Swords",
+    "Nine of Swords",
+    "Ten of Swords",
+    "Page of Swords",
+    "Knight of Swords",
+    "Queen of Swords",
+    "King of Swords",
+    "Ace of Wands",
+    "Two of Wands",
+    "Three of Wands",
+    "Four of Wands",
+    "Five of Wands",
+    "Six of Wands",
+    "Seven of Wands",
+    "Eight of Wands",
+    "Nine of Wands",
+    "Ten of Wands",
+    "Page of Wands",
+    "Knight of Wands",
+    "Queen of Wands",
+    "King of Wands",
+    "Ace of Pentacles",
+    "Two of Pentacles",
+    "Three of Pentacles",
+    "Four of Pentacles",
+    "Five of Pentacles",
+    "Six of Pentacles",
+    "Seven of Pentacles",
+    "Eight of Pentacles",
+    "Nine of Pentacles",
+    "Ten of Pentacles",
+    "Page of Pentacles",
+    "Knight of Pentacles",
+    "Queen of Pentacles",
+    "King of Pentacles",
+]
+
+function shuffle<T>(array: T[]): T[] {
+    const copy = [...array]
+    for (let i = copy.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[copy[i], copy[j]] = [copy[j], copy[i]]
+    }
+    return copy
+}
+
+export function LinearCardSpread({
+    cardsToSelect,
+    onCardsSelected,
+}: {
+    cardsToSelect: number
+    onCardsSelected: (cards: BasicCard[]) => void
+}) {
+    const t = useTranslations("ReadingPage.chooseCards")
+    const deck = useMemo(() => shuffle(TAROT_DECK), [])
+    const [currentIndex, setCurrentIndex] = useState(0)
+    const [selected, setSelected] = useState<BasicCard[]>([])
+
+    const cardRef = useRef<HTMLDivElement | null>(null)
+    const startYRef = useRef<number | null>(null)
+    const deltaYRef = useRef<number>(0)
+    const isDraggingRef = useRef(false)
+
+    useEffect(() => {
+        if (selected.length === cardsToSelect) {
+            onCardsSelected(selected)
+        }
+    }, [selected, cardsToSelect, onCardsSelected])
+
+    const handlePointerDown = (clientY: number) => {
+        isDraggingRef.current = true
+        startYRef.current = clientY
+        deltaYRef.current = 0
+        if (cardRef.current) {
+            cardRef.current.style.transition = "transform 0s, opacity 0s"
+        }
+    }
+
+    const handlePointerMove = (clientY: number) => {
+        if (!isDraggingRef.current || startYRef.current === null) return
+        const deltaY = clientY - startYRef.current
+        deltaYRef.current = deltaY
+        if (cardRef.current) {
+            const translateY = Math.min(0, deltaY) // only allow upwards movement visually
+            const rotate = Math.max(-8, translateY / 20)
+            const opacity = Math.max(0.6, 1 + translateY / 300)
+            cardRef.current.style.transform = `translateY(${translateY}px) rotate(${rotate}deg)`
+            cardRef.current.style.opacity = `${opacity}`
+        }
+    }
+
+    const commitSelection = () => {
+        const name = deck[currentIndex]
+        const isReversed = Math.random() < 0.5
+        const next = [...selected, { name, isReversed }]
+        setSelected(next)
+        setCurrentIndex((i: number) => (i + 1) % deck.length)
+        if (cardRef.current) {
+            cardRef.current.style.transition = "transform 180ms ease, opacity 180ms ease"
+            cardRef.current.style.transform = "translateY(0) rotate(0deg)"
+            cardRef.current.style.opacity = "1"
+        }
+    }
+
+    const resetPosition = () => {
+        if (cardRef.current) {
+            cardRef.current.style.transition = "transform 180ms ease, opacity 180ms ease"
+            cardRef.current.style.transform = "translateY(0) rotate(0deg)"
+            cardRef.current.style.opacity = "1"
+        }
+    }
+
+    const handlePointerUp = () => {
+        if (!isDraggingRef.current) return
+        isDraggingRef.current = false
+
+        const cardEl = cardRef.current
+        if (!cardEl) {
+            return
+        }
+
+        const height = cardEl.getBoundingClientRect().height
+        const draggedUp = -deltaYRef.current // positive when moved up
+        if (draggedUp > height / 2) {
+            commitSelection()
+        } else {
+            resetPosition()
+        }
+
+        startYRef.current = null
+        deltaYRef.current = 0
+    }
+
+    const preventTouchScrollWhileDragging = (e: TouchEvent) => {
+        if (isDraggingRef.current) e.preventDefault()
+    }
+
+    useEffect(() => {
+        // Prevent page scroll while dragging on mobile
+        document.addEventListener("touchmove", preventTouchScrollWhileDragging, {
+            passive: false,
+        })
+        return () => {
+            document.removeEventListener(
+                "touchmove",
+                preventTouchScrollWhileDragging as any
+            )
+        }
+    }, [])
+
+    const remaining = cardsToSelect - selected.length
+    const currentName = deck[currentIndex]
+
+    return (
+        <div className='w-full max-w-md mx-auto'>
+            <div className='relative h-[380px] flex items-center justify-center'>
+                <div
+                    ref={cardRef}
+                    className='w-40 h-64 rounded-xl border-2 border-border/30 bg-card/80 backdrop-blur-sm shadow-md shadow-black/20 flex items-center justify-center select-none touch-none'
+                    onMouseDown={(e: React.MouseEvent<HTMLDivElement>) => handlePointerDown(e.clientY)}
+                    onMouseMove={(e: React.MouseEvent<HTMLDivElement>) => handlePointerMove(e.clientY)}
+                    onMouseUp={handlePointerUp}
+                    onMouseLeave={handlePointerUp}
+                    onTouchStart={(e: React.TouchEvent<HTMLDivElement>) => handlePointerDown(e.touches[0].clientY)}
+                    onTouchMove={(e: React.TouchEvent<HTMLDivElement>) => handlePointerMove(e.touches[0].clientY)}
+                    onTouchEnd={handlePointerUp}
+                    role='button'
+                    aria-label='Swipe up to select card'
+                >
+                    <div className='text-4xl'>🌟</div>
+                </div>
+
+                {/* Gesture indicator overlay on card */}
+                <div className='pointer-events-none absolute inset-0 flex items-end justify-center pb-4'>
+                    <div className='flex flex-col items-center gap-2 text-center'>
+                        <div className='relative w-10 h-10 rounded-full border border-white/20 bg-white/5 overflow-hidden'>
+                            <div className='absolute left-1/2 -translate-x-1/2 bottom-1 w-1.5 h-4 rounded bg-white/70 animate-pulse'></div>
+                            <div className='absolute left-1/2 -translate-x-1/2 bottom-1 w-1.5 h-1.5 rounded-full bg-white/90 animate-[bounce_1.2s_infinite]'></div>
+                        </div>
+                        <div className='text-xs text-muted-foreground'>
+                            {t("swipeUpToSelect", { default: "Swipe up to select" })}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div className='mt-4 text-center space-y-1'>
+                <p className='text-sm text-muted-foreground'>
+                    {t("selectedCount", { selected: cardsToSelect - remaining, total: cardsToSelect })}
+                </p>
+                <p className='text-xs text-muted-foreground'>
+                    {t("hint", { default: "Drag the card upward past halfway to confirm" })}
+                </p>
+            </div>
+
+            <div className='sr-only' aria-live='polite'>
+                {t("currentCard", { default: "Current card" })}: {currentName}
+            </div>
+        </div>
+    )
+}
+
+export default LinearCardSpread
+

--- a/components/reading/card-selection/linear-card-spread.tsx
+++ b/components/reading/card-selection/linear-card-spread.tsx
@@ -113,6 +113,7 @@ export function LinearCardSpread({
     const deck = useMemo(() => shuffle(TAROT_DECK), [])
     const [selected, setSelected] = useState<BasicCard[]>([])
     const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set())
+    const deckRef = useRef<HTMLDivElement | null>(null)
 
     // Active drag state for a slide
     const activeElRef = useRef<HTMLDivElement | null>(null)
@@ -149,19 +150,11 @@ export function LinearCardSpread({
         const el = activeElRef.current
         const name = activeNameRef.current
         if (!el || !name) return
-        const height = el.getBoundingClientRect().height
-        // read current translateY from transform string
-        const matrix = window.getComputedStyle(el).transform
-        let translateY = 0
-        if (matrix && matrix !== "none") {
-            const values = matrix.match(/-?\d+\.?\d*/g)
-            if (values && (values.length === 6 || values.length === 16)) {
-                // 2d or 3d matrix
-                translateY = parseFloat(values[values.length === 6 ? 5 : 13] || "0")
-            }
-        }
-        const draggedUp = -translateY
-        if (draggedUp > height / 2) {
+        const deckRect = deckRef.current?.getBoundingClientRect()
+        const cardRect = el.getBoundingClientRect()
+        const isFullyOutOfDeck = deckRect ? cardRect.bottom <= deckRect.top : false
+
+        if (isFullyOutOfDeck) {
             const isReversed = Math.random() < 0.5
             const next = [...selected, { name, isReversed }]
             setSelected(next)
@@ -183,7 +176,7 @@ export function LinearCardSpread({
     const remaining = cardsToSelect - selected.length
 
     return (
-        <div className='w-full'>
+        <div className='w-full' ref={deckRef}>
             <Swiper
                 modules={[FreeMode]}
                 freeMode={{ enabled: true, momentum: true }}
@@ -199,8 +192,8 @@ export function LinearCardSpread({
                                 <div
                                     className={`w-24 h-36 rounded-xl border-2 backdrop-blur-sm flex items-center justify-center select-none touch-none ${
                                         disabled
-                                            ? "pointer-events-none border-blue-300 bg-blue-600"
-                                            : "border-blue-400 bg-gradient-to-br from-blue-500 to-indigo-600"
+                                            ? "pointer-events-none border-blue-900 bg-blue-900"
+                                            : "border-blue-900 bg-gradient-to-br from-blue-900 to-purple-900"
                                     }`}
                                     onMouseDown={(e: React.MouseEvent<HTMLDivElement>) =>
                                         handleDown(e.clientY, e.currentTarget, name)

--- a/components/reading/card-selection/linear-card-spread.tsx
+++ b/components/reading/card-selection/linear-card-spread.tsx
@@ -190,10 +190,8 @@ export function LinearCardSpread({
                         <SwiperSlide key={`${name}-${idx}`} className='!w-28'>
                             <div className='flex items-center justify-center h-[320px]'>
                                 <div
-                                    className={`w-24 h-36 rounded-xl border-2 backdrop-blur-sm flex items-center justify-center select-none touch-none ${
-                                        disabled
-                                            ? "pointer-events-none border-blue-900 bg-blue-900"
-                                            : "border-blue-900 bg-gradient-to-br from-blue-900 to-purple-900"
+                                    className={`w-24 h-36 rounded-[14px] border-2 border-blue-900 bg-white p-[3px] shadow-2xl select-none touch-none ${
+                                        disabled ? "pointer-events-none" : ""
                                     }`}
                                     onMouseDown={(e: React.MouseEvent<HTMLDivElement>) =>
                                         handleDown(e.clientY, e.currentTarget, name)
@@ -213,7 +211,15 @@ export function LinearCardSpread({
                                     role='button'
                                     aria-label='Swipe up to select card'
                                 >
-                                    <div className='text-2xl'>🌟</div>
+                                    <div className='relative w-full h-full rounded-[10px] bg-gradient-to-br from-[#0a1a3a] to-[#3b0f4a] border border-white/10 shadow-inner flex items-center justify-center'>
+                                        <div className='absolute inset-0 rounded-[10px] pointer-events-none'
+                                            style={{
+                                                background:
+                                                    "radial-gradient(circle at 30% 20%, rgba(255,255,255,0.08), transparent 40%), radial-gradient(circle at 70% 80%, rgba(255,255,255,0.06), transparent 45%)",
+                                            }}
+                                        />
+                                        <div className='text-amber-300 text-xl'>✷</div>
+                                    </div>
                                 </div>
                             </div>
                         </SwiperSlide>

--- a/components/reading/card-selection/linear-card-spread.tsx
+++ b/components/reading/card-selection/linear-card-spread.tsx
@@ -195,12 +195,12 @@ export function LinearCardSpread({
                     const disabled = selectedNames.has(name)
                     return (
                         <SwiperSlide key={`${name}-${idx}`} className='!w-28'>
-                            <div className='flex items-center justify-center h-[420px]'>
+                            <div className='flex items-center justify-center h-[320px]'>
                                 <div
                                     className={`w-24 h-36 rounded-xl border-2 backdrop-blur-sm flex items-center justify-center select-none touch-none ${
                                         disabled
-                                            ? "pointer-events-none border-blue-300/20 bg-blue-600/20"
-                                            : "border-blue-300/40 bg-gradient-to-br from-blue-500/20 to-indigo-500/20"
+                                            ? "pointer-events-none border-blue-300 bg-blue-600"
+                                            : "border-blue-400 bg-gradient-to-br from-blue-500 to-indigo-600"
                                     }`}
                                     onMouseDown={(e: React.MouseEvent<HTMLDivElement>) =>
                                         handleDown(e.clientY, e.currentTarget, name)

--- a/components/reading/card-selection/linear-card-spread.tsx
+++ b/components/reading/card-selection/linear-card-spread.tsx
@@ -197,7 +197,7 @@ export function LinearCardSpread({
         return () => {
             document.removeEventListener(
                 "touchmove",
-                preventTouchScrollWhileDragging as any
+                preventTouchScrollWhileDragging as EventListener
             )
         }
     }, [])

--- a/components/reading/card-selection/linear-card-spread.tsx
+++ b/components/reading/card-selection/linear-card-spread.tsx
@@ -153,7 +153,7 @@ export function LinearCardSpread({
 
         // Aura when passed 3/4 height threshold
         const draggedUp = -translateY
-        const threshold = 0.75 * activeHeightRef.current
+        const threshold = 0.5 * activeHeightRef.current
         if (draggedUp >= threshold) {
             if (!auraOnRef.current && activeElRef.current) {
                 auraOnRef.current = true
@@ -185,7 +185,7 @@ export function LinearCardSpread({
             }
         }
         const draggedUp = -translateY
-        const threshold = 0.75 * height
+        const threshold = 0.5 * height
 
         if (elapsed >= 500 && draggedUp >= threshold) {
             const isReversed = Math.random() < 0.5

--- a/components/reading/card-selection/linear-card-spread.tsx
+++ b/components/reading/card-selection/linear-card-spread.tsx
@@ -193,19 +193,23 @@ export function LinearCardSpread({
                 freeMode={{ enabled: true, momentum: true }}
                 slidesPerView='auto'
                 spaceBetween={-40}
-                className='w-full px-6'
+                className='w-full px-4'
             >
                 {deck.map((name, idx) => {
                     const disabled = selectedNames.has(name)
                     return (
-                        <SwiperSlide key={`${name}-${idx}`} className='!w-20'>
-                            <div className='flex items-center justify-center h-[320px]'>
+                        <SwiperSlide key={`${name}-${idx}`} className='!w-28'>
+                            <div className='flex items-center justify-center h-[420px]'>
                                 <div
-                                    className={`w-16 h-24 rounded-xl border-2 backdrop-blur-sm flex items-center justify-center select-none touch-none transition-opacity ${
+                                    className={`w-24 h-36 rounded-xl border-2 backdrop-blur-sm flex items-center justify-center select-none touch-none transition-opacity ${
                                         disabled
                                             ? "opacity-40 pointer-events-none"
                                             : "opacity-100"
-                                    } ${disabled ? "border-border/20 bg-card/40" : "border-border/30 bg-card/80"}`}
+                                    } ${
+                                        disabled
+                                            ? "border-blue-300/20 bg-blue-600/20"
+                                            : "border-blue-300/40 bg-gradient-to-br from-blue-500/20 to-indigo-500/20"
+                                    }`}
                                     onMouseDown={(e: React.MouseEvent<HTMLDivElement>) =>
                                         handleDown(e.clientY, e.currentTarget, name)
                                     }
@@ -232,7 +236,7 @@ export function LinearCardSpread({
                 })}
             </Swiper>
 
-            <div className='mt-4 text-center space-y-1'>
+            <div className='mt-2 text-center space-y-1'>
                 <p className='text-sm text-muted-foreground'>
                     {t("selectedCount", { selected: cardsToSelect - remaining, total: cardsToSelect })}
                 </p>

--- a/components/reading/card-selection/linear-card-spread.tsx
+++ b/components/reading/card-selection/linear-card-spread.tsx
@@ -142,9 +142,7 @@ export function LinearCardSpread({
         const deltaY = eY - startYRef.current
         const translateY = Math.min(0, deltaY)
         const rotate = Math.max(-8, translateY / 20)
-        const opacity = Math.max(0.6, 1 + translateY / 300)
         activeElRef.current.style.transform = `translateY(${translateY}px) rotate(${rotate}deg)`
-        activeElRef.current.style.opacity = `${opacity}`
     }
 
     const handleUp = () => {
@@ -170,13 +168,11 @@ export function LinearCardSpread({
             setSelectedNames((prev) => new Set(prev).add(name))
             finalizeIfDone(next)
             // Hide/restore element
-            el.style.transition = "transform 180ms ease, opacity 180ms ease"
+            el.style.transition = "transform 180ms ease"
             el.style.transform = "translateY(-120%) rotate(-6deg)"
-            el.style.opacity = "0"
         } else {
-            el.style.transition = "transform 180ms ease, opacity 180ms ease"
+            el.style.transition = "transform 180ms ease"
             el.style.transform = "translateY(0) rotate(0deg)"
-            el.style.opacity = "1"
         }
         // reset
         activeElRef.current = null
@@ -201,13 +197,9 @@ export function LinearCardSpread({
                         <SwiperSlide key={`${name}-${idx}`} className='!w-28'>
                             <div className='flex items-center justify-center h-[420px]'>
                                 <div
-                                    className={`w-24 h-36 rounded-xl border-2 backdrop-blur-sm flex items-center justify-center select-none touch-none transition-opacity ${
+                                    className={`w-24 h-36 rounded-xl border-2 backdrop-blur-sm flex items-center justify-center select-none touch-none ${
                                         disabled
-                                            ? "opacity-40 pointer-events-none"
-                                            : "opacity-100"
-                                    } ${
-                                        disabled
-                                            ? "border-blue-300/20 bg-blue-600/20"
+                                            ? "pointer-events-none border-blue-300/20 bg-blue-600/20"
                                             : "border-blue-300/40 bg-gradient-to-br from-blue-500/20 to-indigo-500/20"
                                     }`}
                                     onMouseDown={(e: React.MouseEvent<HTMLDivElement>) =>

--- a/components/reading/interpretation.tsx
+++ b/components/reading/interpretation.tsx
@@ -11,7 +11,7 @@ import { TarotCard, useTarot } from "@/contexts/tarot-context"
 import { useRouter } from "next/navigation"
 import QuestionInput from "../question-input"
 import { CardImage } from "../card-image"
-import { isFollowUpQuestion, getCleanQuestionText } from "@/lib/question-utils"
+import { getCleanQuestionText } from "@/lib/question-utils"
 import { useTranslations } from "next-intl"
 
 export default function Interpretation() {


### PR DESCRIPTION
Add device-specific card spread selection, enabling desktop-only spread type choice, side-by-side circular spreads, and drag-up-to-confirm for linear spread.

---
<a href="https://cursor.com/background-agent?bcId=bc-d562cd48-715e-4832-a850-02d218ec5a7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d562cd48-715e-4832-a850-02d218ec5a7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

