### PR TITLE
Check Supabase environment variables for Vercel deployment

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -2,8 +2,8 @@
 
 export function validateSupabaseEnv() {
   const requiredVars = {
-    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY,
   }
 
   const missing = Object.entries(requiredVars)

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,8 +1,8 @@
 import { createClient } from "@supabase/supabase-js"
 import { isSupabaseConfigured } from "./env"
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 // Validate environment variables


### PR DESCRIPTION
Allow Supabase client to use either `NEXT_PUBLIC_` or non-prefixed `SUPABASE_` environment variables to resolve Vercel deployment issues.

The Vercel deployment was failing because the Supabase integration might set `SUPABASE_URL` and `SUPABASE_ANON_KEY` directly, while the application code was strictly looking for `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. This change adds fallbacks to ensure the application can correctly initialize Supabase regardless of the prefix used by the deployment environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e324dda-72ee-43ae-850c-7f750e9f27fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e324dda-72ee-43ae-850c-7f750e9f27fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

