### PR TITLE
Allow all known bots in robot.ts

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -16,26 +16,6 @@ export default function robots(): MetadataRoute.Robots {
           '/private/',
         ],
       },
-      {
-        userAgent: 'GPTBot',
-        disallow: '/',
-      },
-      {
-        userAgent: 'Google-Extended',
-        disallow: '/',
-      },
-      {
-        userAgent: 'CCBot',
-        disallow: '/',
-      },
-      {
-        userAgent: 'anthropic-ai',
-        disallow: '/',
-      },
-      {
-        userAgent: 'Claude-Web',
-        disallow: '/',
-      },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,
     host: baseUrl,


### PR DESCRIPTION
Remove specific disallow rules for well-known AI bots in `app/robots.ts` to allow them to access the site.

---
<a href="https://cursor.com/background-agent?bcId=bc-453e2c65-a1b3-477b-b847-ee6b1adb521a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-453e2c65-a1b3-477b-b847-ee6b1adb521a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

