### PR TITLE
Update model to gpt-4.1-mini

### DIFF
--- a/app/api/interpret-cards/question/route.ts
+++ b/app/api/interpret-cards/question/route.ts
@@ -1,6 +1,6 @@
 import { streamText } from "ai"
 
-const MODEL = "openai/gpt-5-mini"
+const MODEL = "openai/gpt-4.1-mini"
 
 export async function POST(req: Request) {
     try {


### PR DESCRIPTION
Update the default AI model to `openai/gpt-4.1-mini`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c9c8421-211d-40e9-b3a9-c49182f9770e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c9c8421-211d-40e9-b3a9-c49182f9770e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

