### PR TITLE
Fix tarot article 500 error

### DIFF
--- a/app/[locale]/articles/tarot/[slug]/page.tsx
+++ b/app/[locale]/articles/tarot/[slug]/page.tsx
@@ -3,19 +3,25 @@ import Image from "next/image"
 import { notFound } from "next/navigation"
 import { getCardBySlug, TAROT_CARDS } from "@/lib/tarot/cards"
 import { getCardMeaning } from "@/lib/tarot/meanings"
+import { routing } from "@/i18n/routing"
 import {
     ArticleLayout,
     type ArticleSection,
 } from "@/components/articles/article-layout"
 
+export const dynamicParams = false
+
 export async function generateStaticParams() {
-    return TAROT_CARDS.map((c) => ({ slug: c.slug }))
+    // Generate all tarot article paths for each supported locale
+    return routing.locales.flatMap((locale) =>
+        TAROT_CARDS.map((c) => ({ locale, slug: c.slug }))
+    )
 }
 
 export async function generateMetadata({
     params,
 }: {
-    params: Promise<{ slug: string }>
+    params: Promise<{ locale: string; slug: string }>
 }): Promise<Metadata> {
     const { slug } = await params
     const card = getCardBySlug(slug)
@@ -35,7 +41,7 @@ export async function generateMetadata({
 export default async function TarotCardArticlePage({
     params,
 }: {
-    params: Promise<{ slug: string }>
+    params: Promise<{ locale: string; slug: string }>
 }) {
     const { slug } = await params
     const card = getCardBySlug(slug)


### PR DESCRIPTION
Statically generate tarot article pages for all locales to fix 500 errors on localized routes.

The previous `generateStaticParams` did not account for the `[locale]` segment, causing Next.js to fail to pre-render localized paths like `/en/articles/tarot/the-chariot`. This resulted in a 404 for the data JSON and a 500 for the page itself. Explicitly including `locale` in `generateStaticParams` and setting `dynamicParams = false` ensures all expected localized paths are built at compile time.

---
<a href="https://cursor.com/background-agent?bcId=bc-26936bf8-4b8e-49f2-854c-9444d085bbd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26936bf8-4b8e-49f2-854c-9444d085bbd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

