### PR TITLE
Fix build errors and warnings

### DIFF
--- a/components/home/discover/roadmap.tsx
+++ b/components/home/discover/roadmap.tsx
@@ -172,7 +172,6 @@ export default function RoadmapSection() {
                             phase.status === t("status.completed")
                         const isInDevelopment =
                             phase.status === t("status.inDevelopment")
-                        const isPlanned = phase.status === t("status.planned")
                         const statusStyle = isCompleted
                             ? "bg-green-500/20 text-green-200 border border-green-400/40"
                             : isInDevelopment

--- a/components/tarot/interpretation/index.tsx
+++ b/components/tarot/interpretation/index.tsx
@@ -30,6 +30,8 @@ type ReadingProps = {
     initialInterpretation?: string | null
     ownerDid?: string | null
     ownerUserId?: string | null
+    isLargeScreen?: boolean
+    onInterpretationChange?: (text: string | null) => void
 }
 
 export default function Interpretation({
@@ -39,6 +41,8 @@ export default function Interpretation({
     initialInterpretation,
     ownerDid,
     ownerUserId,
+    isLargeScreen = false,
+    onInterpretationChange,
 }: ReadingProps) {
     const t = useTranslations("ReadingPage.interpretation")
     const { user } = useAuth()
@@ -51,6 +55,16 @@ export default function Interpretation({
         initialInterpretation ?? null
     )
     const [isGenerating, setIsGenerating] = useState(false)
+
+    useEffect(() => {
+        if (typeof onInterpretationChange === "function") {
+            const normalized =
+                interpretation && interpretation.trim().length > 0
+                    ? interpretation
+                    : null
+            onInterpretationChange(normalized)
+        }
+    }, [interpretation, onInterpretationChange])
     const [error, setError] = useState<string | null>(null)
     const [showNoStarsDialog, setShowNoStarsDialog] = useState(false)
     const [isAuthLoading, setIsAuthLoading] = useState(true)
@@ -395,7 +409,7 @@ Output:
                 </div>
             </Card>
 
-            {interpretation && !error && (
+            {!isLargeScreen && interpretation && !error && (
                 <div className='w-full max-w-4xl space-y-6'>
                     <ActionSection
                         question={question || ""}

--- a/components/tarot/reading-history.tsx
+++ b/components/tarot/reading-history.tsx
@@ -594,13 +594,6 @@ export default function ReadingHistory() {
 
         // If some follow-ups reference a main not in current filter (unlikely), we still create the group
         // Now, heuristically merge remaining unlinked by similarity/time where parent_id is missing
-        const tokenize = (text: string) =>
-            (text || "")
-                .toLowerCase()
-                .replace(/[^a-z0-9\sก-๙]/gi, " ")
-                .split(/\s+/)
-                .filter((w) => w.length >= 3)
-
         type Group = {
             key: string
             items: ReadingRow[]

--- a/components/tarot/reading-layout.tsx
+++ b/components/tarot/reading-layout.tsx
@@ -45,8 +45,6 @@ export default function TarotReadingLayout({
     const [interpretation, setInterpretation] = useState<string | null>(
         initialInterpretation ?? null
     )
-    const [isGenerating, setIsGenerating] = useState(false)
-
     return (
         <div className="hidden lg:block space-y-8">
             {/* Row 1: Cards (left) + Interpretation (right) */}
@@ -140,12 +138,9 @@ export default function TarotReadingLayout({
                             cards={cards || []}
                             interpretation={interpretation}
                             readingId={readingId}
-                            onInterpretationChange={(text) =>
+                            onInterpretationChange={(text) => {
                                 setInterpretation(text)
-                            }
-                            onGeneratingChange={(loading) =>
-                                setIsGenerating(loading)
-                            }
+                            }}
                         />
                     </div>
 


### PR DESCRIPTION
Fix build errors and warnings by updating component props and removing unused variables.

The primary build error was a type mismatch when passing `isLargeScreen` to the `Interpretation` component. This PR extends the `Interpretation` component's props to accept `isLargeScreen` and an `onInterpretationChange` callback, allowing the parent `TarotReadingLayout` to manage the interpretation state and conditionally render action/share sections for large screens. Additionally, several unused variables were removed to clear lint warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-11c1a503-2ea6-4352-a5b9-b391272aaf91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11c1a503-2ea6-4352-a5b9-b391272aaf91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

