### PR TITLE
Fix star deduction for tarot interpretations

### DIFF
--- a/components/tarot/card-selection/index.tsx
+++ b/components/tarot/card-selection/index.tsx
@@ -102,11 +102,7 @@ export default function CardSelection({
     const handleCardsSelected = async (
         cards: { name: string; isReversed: boolean }[]
     ) => {
-        // If not enough stars, block and show dialog; do not mutate state
-        if (!Number.isFinite(stars as number) || (stars as number) < 1) {
-            setShowNoStarsDialog(true)
-            return
-        }
+        // Note: Star check happens when interpretation is generated, not here
         // Clear old interpretation state when new cards are selected
         clearInterpretationState()
 
@@ -152,13 +148,8 @@ export default function CardSelection({
                 }
             } catch {}
 
-            // Deduct star before creating the reading
-            const starSuccess = spendStars(1)
-            if (!starSuccess) {
-                setShowNoStarsDialog(true)
-                setIsCreatingReading(false)
-                return
-            }
+            // Note: Star deduction happens when interpretation is generated, not here
+            // This ensures stars are only deducted when an interpretation is actually created
 
             const response = await fetch("/api/tarot/create", {
                 method: "POST",
@@ -351,7 +342,7 @@ export default function CardSelection({
                                     fill='currentColor'
                                 />
                                 {
-                                    "Starting the interpretation will consume 1 star."
+                                    "Generating the interpretation will consume 1 star."
                                 }
                             </p>
                         </div>

--- a/components/tarot/interpretation/index.tsx
+++ b/components/tarot/interpretation/index.tsx
@@ -54,7 +54,7 @@ export default function Interpretation({
         paidForInterpretation,
         setPaidForInterpretation,
     } = useTarot()
-    const { stars, spendStars } = useStars()
+    const { stars, spendStars, initialized: starsInitialized } = useStars()
     const [interpretation, setInterpretationState] = useState<string | null>(
         initialInterpretation ?? null
     )
@@ -202,12 +202,18 @@ export default function Interpretation({
                     ? `reading:${readingId}:gen`
                     : null
             if (genKey && sessionStorage.getItem(genKey)) return
-            if (genKey) sessionStorage.setItem(genKey, "1")
             
             // Check if stars need to be deducted (only if not already paid and no initial interpretation)
             if (!initialInterpretation && !paidForInterpretation) {
-                // Check if user has enough stars
-                if (!Number.isFinite(stars as number) || (stars as number) < 1) {
+                // Wait for stars to be initialized before checking
+                if (!starsInitialized) {
+                    // Stars not initialized yet, wait for them to load
+                    return
+                }
+                
+                // Check if user has enough stars (stars can be null initially, so check properly)
+                const currentStars = stars ?? 0
+                if (!Number.isFinite(currentStars) || currentStars < 1) {
                     setShowNoStarsDialog(true)
                     setError("Not enough stars to generate interpretation")
                     return
@@ -224,6 +230,9 @@ export default function Interpretation({
                 // Mark as paid
                 setPaidForInterpretation(true)
             }
+            
+            // Only mark as attempted and set sessionStorage after all checks pass
+            if (genKey) sessionStorage.setItem(genKey, "1")
             
             setHasAttemptedGeneration(true)
             setIsGenerating(true)
@@ -316,6 +325,7 @@ Output:
         initialInterpretation,
         paidForInterpretation,
         stars,
+        starsInitialized,
         spendStars,
         setPaidForInterpretation,
     ])

--- a/components/tarot/interpretation/index.tsx
+++ b/components/tarot/interpretation/index.tsx
@@ -205,14 +205,21 @@ export default function Interpretation({
             
             // Check if stars need to be deducted (only if not already paid and no initial interpretation)
             if (!initialInterpretation && !paidForInterpretation) {
-                // Wait for stars to be initialized before checking
+                // Wait for stars to be initialized AND stars value to be loaded
+                // starsInitialized should match the initialized flag in spendStars
                 if (!starsInitialized) {
                     // Stars not initialized yet, wait for them to load
                     return
                 }
                 
-                // Check if user has enough stars (stars can be null initially, so check properly)
-                const currentStars = stars ?? 0
+                // Ensure stars value is actually loaded (not null/undefined)
+                if (stars === null || stars === undefined) {
+                    // Stars value not loaded yet, wait
+                    return
+                }
+                
+                // Check if user has enough stars - must be a valid number >= 1
+                const currentStars = typeof stars === 'number' ? stars : Number(stars)
                 if (!Number.isFinite(currentStars) || currentStars < 1) {
                     setShowNoStarsDialog(true)
                     setError("Not enough stars to generate interpretation")
@@ -220,8 +227,15 @@ export default function Interpretation({
                 }
                 
                 // Deduct star for interpretation
+                // spendStars internally checks initialized. Since starsInitialized is true
+                // and stars is a valid number >= 1, this should succeed.
                 const starSuccess = spendStars(1)
                 if (!starSuccess) {
+                    // spendStars failed despite our checks. This could happen if:
+                    // 1. The initialized flag in spendStars closure is stale (shouldn't happen)
+                    // 2. Stars were spent between our check and the spendStars call
+                    // 3. Some other validation in spendStars failed
+                    // Show error to user
                     setShowNoStarsDialog(true)
                     setError("Not enough stars to generate interpretation")
                     return

--- a/components/tarot/interpretation/index.tsx
+++ b/components/tarot/interpretation/index.tsx
@@ -8,6 +8,7 @@ import QuestionInput from "../../question-input"
 import { useTranslations } from "next-intl"
 import { useAuth } from "@/hooks/use-auth"
 import { useTarot } from "@/contexts/tarot-context"
+import { useStars } from "@/contexts/stars-context"
 import {
     AlertDialog,
     AlertDialogAction,
@@ -50,7 +51,10 @@ export default function Interpretation({
         isFollowUp,
         setInterpretation: setContextInterpretation,
         setQuestion: setContextQuestion,
+        paidForInterpretation,
+        setPaidForInterpretation,
     } = useTarot()
+    const { stars, spendStars } = useStars()
     const [interpretation, setInterpretationState] = useState<string | null>(
         initialInterpretation ?? null
     )
@@ -199,6 +203,28 @@ export default function Interpretation({
                     : null
             if (genKey && sessionStorage.getItem(genKey)) return
             if (genKey) sessionStorage.setItem(genKey, "1")
+            
+            // Check if stars need to be deducted (only if not already paid and no initial interpretation)
+            if (!initialInterpretation && !paidForInterpretation) {
+                // Check if user has enough stars
+                if (!Number.isFinite(stars as number) || (stars as number) < 1) {
+                    setShowNoStarsDialog(true)
+                    setError("Not enough stars to generate interpretation")
+                    return
+                }
+                
+                // Deduct star for interpretation
+                const starSuccess = spendStars(1)
+                if (!starSuccess) {
+                    setShowNoStarsDialog(true)
+                    setError("Not enough stars to generate interpretation")
+                    return
+                }
+                
+                // Mark as paid
+                setPaidForInterpretation(true)
+            }
+            
             setHasAttemptedGeneration(true)
             setIsGenerating(true)
             setError(null)
@@ -287,6 +313,11 @@ Output:
         complete,
         readingId,
         isFollowUp,
+        initialInterpretation,
+        paidForInterpretation,
+        stars,
+        spendStars,
+        setPaidForInterpretation,
     ])
 
     useEffect(() => {


### PR DESCRIPTION
Move star deduction for tarot interpretations to the interpretation generation step to ensure reliable payment and prevent premature deductions.

The previous logic deducted stars optimistically in the card selection component before redirection, which could lead to server-side deduction not completing or the interpretation component not verifying payment. This fix ensures stars are only deducted when an interpretation is actually generated and only if the user hasn't already paid and has sufficient stars.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7e6d16f-4842-4365-8d3b-549f8bce29b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7e6d16f-4842-4365-8d3b-549f8bce29b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

