### PR TITLE
Beta test announcement modal

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import "../globals.css"
 import Footer from "@/components/footer/footer"
 import CosmicStars from "@/components/cosmic-stars"
 import { Toaster } from "sonner"
+import { BetaAnnouncementModal } from "@/components/beta-announcement-modal"
 import { hasLocale } from "next-intl"
 import { routing } from "@/i18n/routing"
 import { notFound } from "next/navigation"
@@ -137,6 +138,7 @@ export default async function RootLayout({
                     richColors
                     closeButton
                 />
+                <BetaAnnouncementModal />
             </body>
         </html>
     )

--- a/components/beta-announcement-modal.tsx
+++ b/components/beta-announcement-modal.tsx
@@ -38,7 +38,7 @@ export function BetaAnnouncementModal() {
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
-            <BetaDialog className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 relative overflow-hidden'>
+            <BetaDialog className='relative overflow-hidden'>
                 <DialogHeader className='text-center space-y-4'>
                     <DialogTitle className='text-yellow-300 font-serif text-xl'>
                         Beta Testing Notice

--- a/components/beta-announcement-modal.tsx
+++ b/components/beta-announcement-modal.tsx
@@ -50,10 +50,11 @@ export function BetaAnnouncementModal() {
                             or unexpected behavior while using our services.
                         </p>
                         <p className='text-sm text-white/75'>
-                            We appreciate your patience and feedback as we work to
-                            improve the experience. If you encounter any issues,
-                            please don&apos;t hesitate to reach out to our support
-                            team.
+                            Please note that some features will be unavailable as they
+                            are still in development. We appreciate your patience and
+                            feedback as we work to improve the experience. If you
+                            encounter any issues, please don&apos;t hesitate to reach
+                            out to our support team.
                         </p>
                     </DialogDescription>
                 </DialogHeader>

--- a/components/beta-announcement-modal.tsx
+++ b/components/beta-announcement-modal.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+
+const STORAGE_KEY = "beta-announcement-seen"
+
+export function BetaAnnouncementModal() {
+    const [open, setOpen] = useState(false)
+
+    useEffect(() => {
+        // Check if user has seen the announcement
+        const hasSeen = localStorage.getItem(STORAGE_KEY)
+        if (!hasSeen) {
+            // Small delay to ensure smooth page load
+            setTimeout(() => {
+                setOpen(true)
+            }, 500)
+        }
+    }, [])
+
+    const handleClose = () => {
+        setOpen(false)
+        // Mark as seen in localStorage
+        localStorage.setItem(STORAGE_KEY, "true")
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogContent className="sm:max-w-[500px]">
+                <DialogHeader>
+                    <DialogTitle className="text-2xl font-bold">
+                        Beta Testing Notice
+                    </DialogTitle>
+                    <DialogDescription className="text-base pt-2">
+                        Welcome to our platform! We&apos;re currently in beta
+                        testing, which means you might experience several bugs
+                        or unexpected behavior while using our services.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="py-4">
+                    <p className="text-sm text-muted-foreground">
+                        We appreciate your patience and feedback as we work to
+                        improve the experience. If you encounter any issues,
+                        please don&apos;t hesitate to reach out to our support
+                        team.
+                    </p>
+                </div>
+                <DialogFooter>
+                    <Button onClick={handleClose} className="w-full sm:w-auto">
+                        I Understand
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/components/beta-announcement-modal.tsx
+++ b/components/beta-announcement-modal.tsx
@@ -27,14 +27,16 @@ export function BetaAnnouncementModal() {
         }
     }, [])
 
-    const handleClose = () => {
-        setOpen(false)
-        // Mark as seen in localStorage
-        localStorage.setItem(STORAGE_KEY, "true")
+    const handleOpenChange = (isOpen: boolean) => {
+        setOpen(isOpen)
+        // If dialog is being closed, mark as seen in localStorage
+        if (!isOpen) {
+            localStorage.setItem(STORAGE_KEY, "true")
+        }
     }
 
     return (
-        <Dialog open={open} onOpenChange={setOpen}>
+        <Dialog open={open} onOpenChange={handleOpenChange}>
             <DialogContent className="sm:max-w-[500px]">
                 <DialogHeader>
                     <DialogTitle className="text-2xl font-bold">
@@ -55,7 +57,10 @@ export function BetaAnnouncementModal() {
                     </p>
                 </div>
                 <DialogFooter>
-                    <Button onClick={handleClose} className="w-full sm:w-auto">
+                    <Button
+                        onClick={() => handleOpenChange(false)}
+                        className="w-full sm:w-auto"
+                    >
                         I Understand
                     </Button>
                 </DialogFooter>

--- a/components/beta-announcement-modal.tsx
+++ b/components/beta-announcement-modal.tsx
@@ -5,11 +5,12 @@ import {
     Dialog,
     DialogContent,
     DialogDescription,
-    DialogFooter,
     DialogHeader,
     DialogTitle,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
+import { Sparkle } from "lucide-react"
+import { cn } from "@/lib/utils"
 
 const STORAGE_KEY = "beta-announcement-seen"
 
@@ -37,34 +38,108 @@ export function BetaAnnouncementModal() {
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
-            <DialogContent className="sm:max-w-[500px]">
-                <DialogHeader>
-                    <DialogTitle className="text-2xl font-bold">
+            <BetaDialog className='fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 relative overflow-hidden'>
+                <DialogHeader className='text-center space-y-4'>
+                    <DialogTitle className='text-yellow-300 font-serif text-xl'>
                         Beta Testing Notice
                     </DialogTitle>
-                    <DialogDescription className="text-base pt-2">
-                        Welcome to our platform! We&apos;re currently in beta
-                        testing, which means you might experience several bugs
-                        or unexpected behavior while using our services.
+                    <DialogDescription className='text-white/85 text-center leading-relaxed space-y-3'>
+                        <p>
+                            Welcome to our platform! We&apos;re currently in beta
+                            testing, which means you might experience several bugs
+                            or unexpected behavior while using our services.
+                        </p>
+                        <p className='text-sm text-white/75'>
+                            We appreciate your patience and feedback as we work to
+                            improve the experience. If you encounter any issues,
+                            please don&apos;t hesitate to reach out to our support
+                            team.
+                        </p>
                     </DialogDescription>
                 </DialogHeader>
-                <div className="py-4">
-                    <p className="text-sm text-muted-foreground">
-                        We appreciate your patience and feedback as we work to
-                        improve the experience. If you encounter any issues,
-                        please don&apos;t hesitate to reach out to our support
-                        team.
-                    </p>
-                </div>
-                <DialogFooter>
+                <div className='flex justify-center mt-6'>
                     <Button
                         onClick={() => handleOpenChange(false)}
-                        className="w-full sm:w-auto"
+                        className='px-6 py-2 rounded-md bg-gradient-to-r from-yellow-400 to-yellow-600 text-black border border-yellow-500/40 hover:from-yellow-300 hover:to-yellow-500 shadow-[0_12px_30px_-10px_rgba(234,179,8,0.45)] font-medium'
                     >
                         I Understand
                     </Button>
-                </DialogFooter>
-            </DialogContent>
+                </div>
+            </BetaDialog>
         </Dialog>
+    )
+}
+
+function BetaDialog({
+    children,
+    className,
+}: {
+    children: React.ReactNode
+    className?: string
+}) {
+    return (
+        <DialogContent
+            className={cn(
+                "max-w-lg w-[92vw] border border-yellow-400/20 bg-gradient-to-br from-[#0a0a1a]/95 via-[#0d0b1f]/90 to-[#0a0a1a]/95 backdrop-blur-xl shadow-[0_10px_40px_-10px_rgba(234,179,8,0.35)]",
+                className
+            )}
+        >
+            {/* Beautiful ping orbs */}
+            <Sparkle
+                className='absolute top-16 left-16 w-3 h-3 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "0.5s" }}
+            />
+            <Sparkle
+                className='absolute top-24 right-20 w-2 h-2 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "1.2s" }}
+            />
+            <Sparkle
+                className='absolute top-40 left-1/3 w-2.5 h-2.5 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "2.8s" }}
+            />
+            <Sparkle
+                className='absolute top-32 right-1/4 w-1.5 h-1.5 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "3.5s" }}
+            />
+            <Sparkle
+                className='absolute bottom-20 left-20 w-3.5 h-3.5 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "1.8s" }}
+            />
+            <Sparkle
+                className='absolute bottom-32 right-16 w-2 h-2 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "4.2s" }}
+            />
+            <Sparkle
+                className='absolute bottom-16 right-1/3 w-2.5 h-2.5 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "2.1s" }}
+            />
+            <Sparkle
+                className='absolute top-1/2 left-12 w-1.5 h-1.5 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "3.8s" }}
+            />
+            <Sparkle
+                className='absolute top-1/3 right-12 w-3 h-3 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "0.9s" }}
+            />
+            <Sparkle
+                className='absolute bottom-1/3 left-1/4 w-2 h-2 rounded-full fill-yellow-400 opacity-50 animate-ping'
+                style={{ animationDelay: "4.7s" }}
+            />
+
+            {/* Deep-space stars background */}
+            <div className='pointer-events-none absolute inset-0 opacity-40'>
+                <div className='cosmic-stars-layer-3' />
+                <div className='cosmic-stars-layer-4' />
+                <div className='cosmic-stars-layer-5' />
+            </div>
+            {/* Golden aura behind dialog */}
+            <div className='pointer-events-none absolute -top-24 -left-24 h-64 w-64 rounded-full bg-gradient-to-br from-yellow-300/25 via-yellow-500/15 to-transparent blur-3xl animate-pulse' />
+            <div
+                className='pointer-events-none absolute -bottom-28 -right-28 h-80 w-80 rounded-full bg-gradient-to-tl from-yellow-400/20 via-yellow-600/10 to-transparent blur-[100px] animate-pulse'
+                style={{ animationDelay: "0.8s" }}
+            />
+
+            {children}
+        </DialogContent>
     )
 }


### PR DESCRIPTION
Add a beta announcement modal that displays once to first-time visitors and uses local storage to remember dismissal.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3b25e7a-72df-4522-bd28-da51de003c09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3b25e7a-72df-4522-bd28-da51de003c09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a beta announcement modal shown once per browser via localStorage and renders it in the root layout.
> 
> - **Frontend/UI**:
>   - **New Component**: `components/beta-announcement-modal.tsx`
>     - Dialog explaining beta status with dismiss button; delayed open.
>     - Persistence via `localStorage` key `beta-announcement-seen` to show once per browser.
>     - Custom styling and sparkle animations.
>   - **Integration**: `app/[locale]/layout.tsx` now renders `BetaAnnouncementModal` after `Toaster`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dc930df220a657fdbf8c66271e146e91993b0c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->