### PR TITLE
Beta test toast position

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -133,7 +133,7 @@ export default async function RootLayout({
                 </NextIntlClientProvider>
                 <Analytics />
                 <Toaster
-                    position='top-center'
+                    position='bottom-center'
                     theme='dark'
                     richColors
                     closeButton

--- a/components/beta-announcement-modal.tsx
+++ b/components/beta-announcement-modal.tsx
@@ -18,7 +18,7 @@ export function BetaAnnouncementModal() {
                     icon: <Sparkle className='h-4 w-4 text-yellow-300' />,
                     duration: 12000,
                     className:
-                        "fixed bottom-6 left-1/2 z-[100] w-[92vw] max-w-md -translate-x-1/2 border border-yellow-400/20 bg-gradient-to-br from-[#0a0a1a]/95 via-[#0d0b1f]/90 to-[#0a0a1a]/95 text-white shadow-[0_10px_40px_-10px_rgba(234,179,8,0.35)]",
+                        "w-[92vw] max-w-md border border-yellow-400/20 bg-gradient-to-br from-[#0a0a1a]/95 via-[#0d0b1f]/90 to-[#0a0a1a]/95 text-white shadow-[0_10px_40px_-10px_rgba(234,179,8,0.35)]",
                 })
             }, 500)
 


### PR DESCRIPTION
Reposition the beta test toast to the bottom of the screen by aligning with the global Toaster configuration.

The beta test toast was using conflicting manual CSS positioning classes while the global `Toaster` was configured for `top-center`, leading to unpredictable placement. This PR updates the global `Toaster` to `bottom-center` and removes the redundant manual positioning from the beta toast, ensuring it appears correctly at the bottom.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f422474-45f4-458b-941b-a39a289d273c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f422474-45f4-458b-941b-a39a289d273c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

