### PR TITLE
Tarot prompt swiper bugs

### DIFF
--- a/components/home/index.tsx
+++ b/components/home/index.tsx
@@ -141,7 +141,7 @@ export default function Home() {
                                             key={feature.id}
                                             className='w-full h-full'
                                         >
-                                            <div className='w-full h-full flex flex-col items-center justify-end pb-18'>
+                                            <div className='w-full h-full flex flex-col items-center justify-end pb-18 overflow-hidden'>
                                                 <FeatureComponent />
                                             </div>
                                         </SwiperSlide>

--- a/components/home/question.tsx
+++ b/components/home/question.tsx
@@ -22,6 +22,7 @@ export default function Question({
                 value={inputValue}
                 onChange={setInputValue}
                 label={t("label")}
+                centered
             />
             <div className='mx-6'>
                 <SuggestionPromptCard

--- a/components/question-input.tsx
+++ b/components/question-input.tsx
@@ -18,6 +18,7 @@ export default function QuestionInput({
     onChange,
     followUp = false,
     followUpParentId,
+    centered = false,
 }: {
     id?: string
     label?: string
@@ -27,6 +28,7 @@ export default function QuestionInput({
     onChange?: (value: string) => void
     followUp?: boolean
     followUpParentId?: string
+    centered?: boolean
 }) {
     const t = useTranslations("QuestionInput")
     // removed unused pathname
@@ -162,11 +164,17 @@ export default function QuestionInput({
     }
 
     return (
-        <div className='w-full mb-6 text-left'>
+        <div
+            className={`w-full mb-6 ${centered ? "text-center" : "text-left"}`}
+        >
             <Label htmlFor={id} className='block mb-2 text-lg'>
                 {label}
             </Label>
-            <div className='relative group max-w-sm md:max-w-md'>
+            <div
+                className={`relative group max-w-sm md:max-w-md ${
+                    centered ? "mx-auto" : ""
+                }`}
+            >
                 <div className='pointer-events-none absolute inset-0 rounded-2xl bg-[radial-gradient(120%_120%_at_0%_0%,rgba(99,102,241,0.18),rgba(168,85,247,0.12)_35%,rgba(34,211,238,0.10)_70%,transparent_80%)] blur-xl opacity-90 group-focus-within:opacity-0 transition-opacity' />
                 <AutoHeightTextarea
                     id={id}

--- a/components/suggestion-prompt-card.tsx
+++ b/components/suggestion-prompt-card.tsx
@@ -330,6 +330,7 @@ export default function SuggestionPromptCard({
                         }}
                         speed={8000}
                         loop={true}
+                        nested={true}
                         className='suggestion-swiper'
                     >
                         {selectedCategory.questions.map((question, index) => (

--- a/components/suggestion-prompt-card.tsx
+++ b/components/suggestion-prompt-card.tsx
@@ -190,8 +190,12 @@ export default function SuggestionPromptCard({
         onSuggestionClick(suggestion)
     }
 
-    const handleSwiperInteraction = () => {
-        const swiper = swiperRef.current
+    const handleSwiperInteraction = (swiper: SwiperType, event: any) => {
+        // Stop propagation to prevent parent swiper from taking over
+        if (event && event.stopPropagation) {
+            event.stopPropagation()
+        }
+
         if (!swiper) return
 
         // Pause autoplay

--- a/components/suggestion-prompt-card.tsx
+++ b/components/suggestion-prompt-card.tsx
@@ -345,7 +345,7 @@ export default function SuggestionPromptCard({
                             reverseDirection: false,
                         }}
                         speed={8000}
-                        loop={true}
+                        loop={false}
                         nested={true}
                         className='suggestion-swiper'
                     >

--- a/components/suggestion-prompt-card.tsx
+++ b/components/suggestion-prompt-card.tsx
@@ -190,12 +190,8 @@ export default function SuggestionPromptCard({
         onSuggestionClick(suggestion)
     }
 
-    const handleSwiperInteraction = (swiper: SwiperType, event: any) => {
-        // Stop propagation to prevent parent swiper from taking over
-        if (event && event.stopPropagation) {
-            event.stopPropagation()
-        }
-
+    const manageAutoplay = () => {
+        const swiper = swiperRef.current
         if (!swiper) return
 
         // Pause autoplay
@@ -210,6 +206,22 @@ export default function SuggestionPromptCard({
         pauseTimeoutRef.current = setTimeout(() => {
             swiper.autoplay?.resume()
         }, 3000)
+    }
+
+    const handleSwiperEvent = (swiper: SwiperType, event: any) => {
+        // Stop propagation to prevent parent swiper from taking over
+        if (event && event.stopPropagation) {
+            event.stopPropagation()
+        }
+        manageAutoplay()
+    }
+
+    const handleMouseEvent = (event: React.MouseEvent | React.TouchEvent | any) => {
+        // Stop propagation to prevent parent swiper from taking over
+        if (event && event.stopPropagation) {
+            event.stopPropagation()
+        }
+        manageAutoplay()
     }
 
     // Cleanup timeout on unmount
@@ -308,12 +320,12 @@ export default function SuggestionPromptCard({
                         onSwiper={(swiper) => {
                             swiperRef.current = swiper
                         }}
-                        onTouchStart={handleSwiperInteraction}
-                        onTouchMove={handleSwiperInteraction}
-                        onTouchEnd={handleSwiperInteraction}
-                        onMouseDown={handleSwiperInteraction}
-                        onMouseMove={handleSwiperInteraction}
-                        onMouseUp={handleSwiperInteraction}
+                        onTouchStart={handleSwiperEvent}
+                        onTouchMove={handleSwiperEvent}
+                        onTouchEnd={handleSwiperEvent}
+                        onMouseDown={handleMouseEvent}
+                        onMouseMove={handleMouseEvent}
+                        onMouseUp={handleMouseEvent}
                         modules={[Autoplay, FreeMode]}
                         spaceBetween={12}
                         slidesPerView='auto'


### PR DESCRIPTION
Fixes layout shift and swiper interaction issues when opening tarot question categories.

The layout shift occurred because the `QuestionInput` was not centered within its expanding parent container. The swiper conflict arose because the inner "inspiring prompts" swiper's touch events were being consumed by the outer "feature" swiper, preventing the prompts from being swiped.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba1bbb0a-d97e-469c-a790-55a70786c2f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ba1bbb0a-d97e-469c-a790-55a70786c2f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

