### PR TITLE
Edge input scrollbar removal

### DIFF
--- a/components/navbar/mystical-services-sheet.tsx
+++ b/components/navbar/mystical-services-sheet.tsx
@@ -37,7 +37,7 @@ export default function MysticalServicesSheet({
             </SheetTrigger>
             <SheetContent
                 side='right'
-                className='w-80 bg-card/95 backdrop-blur-md border-border/30 p-0'
+                className='w-80 bg-card/95 backdrop-blur-md border-border/30 p-0 overflow-y-auto scrollbar-hide'
             >
                 <div className='px-4 py-4 border-b border-white/10'>
                     <SheetHeader>

--- a/components/navbar/mystical-services-sheet.tsx
+++ b/components/navbar/mystical-services-sheet.tsx
@@ -37,7 +37,7 @@ export default function MysticalServicesSheet({
             </SheetTrigger>
             <SheetContent
                 side='right'
-                className='w-80 bg-card/95 backdrop-blur-md border-border/30 p-0 overflow-y-auto scrollbar-hide'
+                className='w-80 bg-card/95 backdrop-blur-md border-border/30 p-0 overflow-y-auto scrollbar-hide appearance-none'
             >
                 <div className='px-4 py-4 border-b border-white/10'>
                     <SheetHeader>

--- a/components/navbar/sidebar-sheet.tsx
+++ b/components/navbar/sidebar-sheet.tsx
@@ -128,7 +128,7 @@ export function SidebarSheet({ open, onOpenChange }: SidebarSheetProps) {
                 </div>
 
                 {/* Scrollable Navigation Section */}
-                <div className='flex-1 overflow-y-auto px-4'>
+                <div className='flex-1 overflow-y-auto px-4 scrollbar-hide'>
                     <nav>
                         <ul className='flex flex-col space-y-1'>
                             <li>

--- a/components/navbar/sidebar-sheet.tsx
+++ b/components/navbar/sidebar-sheet.tsx
@@ -128,7 +128,7 @@ export function SidebarSheet({ open, onOpenChange }: SidebarSheetProps) {
                 </div>
 
                 {/* Scrollable Navigation Section */}
-                <div className='flex-1 overflow-y-auto px-4 scrollbar-hide'>
+                <div className='flex-1 overflow-y-auto px-4 scrollbar-hide appearance-none'>
                     <nav>
                         <ul className='flex flex-col space-y-1'>
                             <li>

--- a/components/ui/auto-height-textarea.tsx
+++ b/components/ui/auto-height-textarea.tsx
@@ -40,7 +40,7 @@ export default function AutoHeightTextarea({
             {...props}
             ref={ref}
             onChange={handleChange}
-            className={`${className} min-h-[40px] max-h-[200px] resize-none overflow-x-hidden scrollbar-hide`}
+            className={`${className} min-h-[40px] max-h-[200px] resize-none overflow-x-hidden scrollbar-hide appearance-none`}
         />
     )
 }

--- a/components/ui/auto-height-textarea.tsx
+++ b/components/ui/auto-height-textarea.tsx
@@ -40,7 +40,7 @@ export default function AutoHeightTextarea({
             {...props}
             ref={ref}
             onChange={handleChange}
-            className={`${className} min-h-[40px] max-h-[200px] resize-none overflow-hidden-x`}
+            className={`${className} min-h-[40px] max-h-[200px] resize-none overflow-x-hidden scrollbar-hide`}
         />
     )
 }


### PR DESCRIPTION
Remove the scrollbar from the question input text area and correct an overflow utility class.

The user requested to remove the scrollbar from the question input text area, especially on Edge browser, which is addressed by adding the `scrollbar-hide` utility class. The `overflow-hidden-x` typo was also corrected to `overflow-x-hidden` for accurate horizontal overflow management.

---
<a href="https://cursor.com/background-agent?bcId=bc-a28f91ba-2657-4629-a495-32a5696c7a2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a28f91ba-2657-4629-a495-32a5696c7a2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

