### PR TITLE
Tarot badge styling consistency

### DIFF
--- a/components/tarot/card-selection/index.tsx
+++ b/components/tarot/card-selection/index.tsx
@@ -318,10 +318,11 @@ export default function CardSelection({
                                         &rdquo;
                                     </p>
                                     <Badge
-                                        className={`text-sm text-primary bg-transparent border-primary/50 ${
+                                        variant="secondary"
+                                        className={`text-sm bg-white/20 text-white/80 border-primary/30 ${
                                             isFollowUp
                                                 ? "cursor-default"
-                                                : "cursor-pointer hover:bg-primary/10 transition-colors"
+                                                : "cursor-pointer hover:bg-white/30 transition-colors"
                                         }`}
                                         onClick={
                                             isFollowUp

--- a/components/tarot/reading-type.tsx
+++ b/components/tarot/reading-type.tsx
@@ -113,7 +113,7 @@ export default function ReadingType({
                                 <div className='flex justify-center'>
                                     <Badge
                                         variant='secondary'
-                                        className='bg-primary/20 text-primary border-primary/30 px-4 py-2'
+                                        className='bg-white/20 text-white/80 border-primary/30 px-4 py-2'
                                     >
                                         {t("followUp.simple")}
                                     </Badge>


### PR DESCRIPTION
Unify the coloring of the reading type badge on `/tarot` with the card name badge on `/tarot/[id]`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e9056da-c470-4507-801a-623ad717b526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e9056da-c470-4507-801a-623ad717b526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

