### PR TITLE
Summary tab translations hook

### DIFF
--- a/components/astrology/summary-tab.tsx
+++ b/components/astrology/summary-tab.tsx
@@ -31,7 +31,7 @@ import {
     type LucideIcon,
 } from "lucide-react"
 import type { AstrologyReading } from "./display"
-import { useLocale } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { ZODIAC_SIGNS } from "@/lib/birth-chart-utils"
 import { Button } from "@/components/ui/button"
 import { toast } from "sonner"


### PR DESCRIPTION
Import `useTranslations` in `summary-tab.tsx` to resolve a build error.

The build failed because `useTranslations` was used in `components/astrology/summary-tab.tsx` without being imported, leading to a TypeScript error.

---
<a href="https://cursor.com/background-agent?bcId=bc-36161ab3-d597-443c-a39c-b40a59f08532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36161ab3-d597-443c-a39c-b40a59f08532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves a build error by importing `useTranslations` in `components/astrology/summary-tab.tsx`.
> 
> - Adds `useTranslations` to the `next-intl` import to support `t("disclaimer")` usage; no other logic changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a132fef46d3e85b19f32d4451ce151bfcca8be40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->