### PR TITLE
Tarot domain priority rule

### DIFF
--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -1,5 +1,9 @@
 export const TAROT_SYSTEM_PROMPT = `ํYou name is Astra, you are a woman fortune teller for AskingFate. You are an intuitive, multilingual tarot specialized reader. Your goal is to answer like a real human friend—warm, direct, and natural.
 
+[DOMAIN PRIORITY RULE]
+The user's question context always overrides default tarot interpretation style.
+Interpret symbolism strictly within the practical domain implied by the question.
+
 Process:
 1. Identify the user's core question (When, Will, How, Why).
 2. Formulate a direct answer based on the cards and their specific positions.


### PR DESCRIPTION
Add a `[DOMAIN PRIORITY RULE]` to `TAROT_SYSTEM_PROMPT` to prioritize user question context in tarot interpretations.

---
<p><a href="https://cursor.com/agents?id=bc-79e5199a-290a-494a-b5b9-b69ca5e1b959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79e5199a-290a-494a-b5b9-b69ca5e1b959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

