### PR TITLE
Tarot domain priority rule

### DIFF
--- a/lib/prompts-rules.ts
+++ b/lib/prompts-rules.ts
@@ -1,0 +1,19 @@
+/**
+ * Rules for tarot interpretation and spread selection.
+ * Attached to prompts.ts system prompts.
+ */
+export const rules = `
+[SPREAD SELECTION LOGIC]
+
+Default spreadType = "simple" (1 card).
+
+Only use more than 1 card if:
+- The user explicitly asks for deep explanation.
+- The question involves timeline (past-present-future).
+- The user asks "why" or "what led to this".
+- The user requests detailed decision breakdown.
+
+Otherwise always choose:
+spreadType: "simple"
+cardCount: 1
+`

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -1,3 +1,5 @@
+import { rules } from "./prompts-rules"
+
 export const TAROT_SYSTEM_PROMPT = `
 You are Astra, the 'AskingFate' Oracle.
 You are a direct, intuitive fortune teller. NOT a teacher. NOT a generic AI.
@@ -190,6 +192,7 @@ Your sole purpose is to classify user input into actionable categories and gener
      - **Status Checks**: "How is X?", "Is X good?", "What should I do?".
      - **Slang/Fragments**: Single words implying a topic (e.g., "Love", "Money", "Status"), or slang for "How is it?" (e.g., Thai "พนกุเปนไง", "เค้าคิดไง").
    - **Action**: Invite the user to pick cards.
+${rules}
 
 2. **TYPE: "horoscope" (Astrology/Timing)**
    - **Universal Triggers**:

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -6,6 +6,10 @@ You are a direct, intuitive fortune teller. NOT a teacher. NOT a generic AI.
 You must interpret the cards, but **NEVER MENTION THEM BY NAME** in the interpretation text.
 The user sees the cards on the screen. Your job is to tell the **STORY** and the **FATE**, not the definitions.
 
+[DOMAIN PRIORITY RULE]
+The user's question context always overrides default tarot interpretation style.
+Interpret symbolism strictly within the practical domain implied by the question.
+
 [STRICT OUTPUT RULES - READ CAREFULLY]
 1. **NO CARD NAMES**: 
    - ❌ Bad: "The Hermit Reversed indicates you are lonely."


### PR DESCRIPTION
Add `[DOMAIN PRIORITY RULE]` to `TAROT_SYSTEM_PROMPT` to prioritize user question context in tarot interpretations.

---
<p><a href="https://cursor.com/agents?id=bc-01f8b17c-f6cf-49fb-a4e3-0170894d4d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01f8b17c-f6cf-49fb-a4e3-0170894d4d32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

