### PR TITLE
Tarot interpretation type error

### DIFF
--- a/components/tarot/interpretation/index.tsx
+++ b/components/tarot/interpretation/index.tsx
@@ -619,7 +619,7 @@ export default function Interpretation({
                     <ActionSection
                         question={question || ""}
                         cards={cards || []}
-                        interpretation={interpretation}
+                        interpretation={interpretation ?? undefined}
                         readingId={readingId!}
                         onInterpretationChange={(text) =>
                             setInterpretationState(text)
@@ -632,7 +632,7 @@ export default function Interpretation({
                     <ShareSection
                         question={question || ""}
                         cards={cards || []}
-                        interpretation={interpretation}
+                        interpretation={interpretation ?? undefined}
                         readingId={readingId!}
                     />
                     <div className='border-t border-border/50 pt-4 flex justify-center'>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Normalize `interpretation` prop from `string | null` to `string | undefined` to resolve a TypeScript build error.

The build failed because a component expected `string | undefined` for the `interpretation` prop, but was receiving `string | null`. This change explicitly converts `null` to `undefined` using the nullish coalescing operator (`??`), aligning the prop type with the component's expectation.

---
<p><a href="https://cursor.com/agents/bc-b49b7bf3-a481-4744-8e8a-1b15eb82f0bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b49b7bf3-a481-4744-8e8a-1b15eb82f0bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->