### PR TITLE
fix(referral): remove stray brace breaking Turbopack parse

### DIFF
--- a/app/[locale]/referral/page.tsx
+++ b/app/[locale]/referral/page.tsx
@@ -480,6 +480,3 @@ export default function ReferralPage() {
     )
 }
 
-}
-
-


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vercel builds failed with a Turbopack parse error on `app/[locale]/referral/page.tsx` at line 483 (`Expression expected`). The file had an extra `}` after the default export component closed.

## Changes

- Remove the stray closing brace and trailing blank lines at the end of the referral page.

## Verification

- Local `npm run build`: Turbopack compiled successfully; the run then failed at page data collection due to missing `NEXT_PUBLIC_SUPABASE_*` / Stripe env (expected in this environment), not due to syntax.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d097e3fe-9718-46ec-ab2d-be93b9bae194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d097e3fe-9718-46ec-ab2d-be93b9bae194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

