### PR TITLE
Shorter AI follow-up chips in a single-row composer swiper

### DIFF
--- a/app/api/horoscope/question/route.ts
+++ b/app/api/horoscope/question/route.ts
@@ -283,7 +283,7 @@ CRITICAL: You MUST write your ENTIRE response (interpretation, conclusion, sugge
 
 CRITICAL: When citing time periods, use dates in the SAME language as your output. Thai output = Thai month names (กุมภาพันธ์, มีนาคม, etc.). English output = English month names (February, March, etc.). Example: Thai "22 กุมภาพันธ์ 2026 ถึง 22 กุมภาพันธ์ 2028"; English "February 22, 2026 to February 22, 2028". Do NOT use ISO format (YYYY-MM-DD). Never mix languages (e.g. Thai text with "February").
 
-Output structure: Provide interpretation (main reading), conclusion (short calming wrap-up), and suggestions (3-5 follow-up questions the user could ask next, written as user questions).`,
+Output structure: Provide interpretation (main reading), conclusion (short calming wrap-up), and suggestions (EXACTLY 3–4 very short, casual follow-up prompts the user could ask next — single line each, like quick texts, not long formal questions).`,
             prompt,
             temperature: 0.6,
         })

--- a/app/api/interpret-cards/question/route.ts
+++ b/app/api/interpret-cards/question/route.ts
@@ -177,9 +177,9 @@ CRITICAL NARRATOR RULE: If a <reading_direction> is provided, you MUST follow it
   - keyMessage = headline + ' ' + subtitle (joined into one short paragraph).
   - interpretation = perCard[].sentence joined together with spaces as one short paragraph.
   - conclusion = nextStep (verbatim).
-- suggestions MUST contain EXACTLY 2 items — never 1, never 3+.
-- The two suggestions MUST be distinctly different angles (different topic, perspective, or scope). They MUST NOT be paraphrases or near-rephrasings of each other.
-- suggestions must feel like natural real-life follow-up questions the user could ask next.
+- suggestions MUST contain EXACTLY 3–4 items — never fewer than 3, never more than 4.
+- Each suggestion must be VERY short (aim ≤8 Thai words or ≤6 English words), one line, like something a friend would text — not a long formal question.
+- All suggestions MUST be clearly different angles (different topic, perspective, or scope). They MUST NOT be paraphrases or near-rephrasings of each other.
 - suggestions must stay generic and user-relatable rather than depending on the exact wording of the generated reading.
 - suggestions must NOT quote or closely paraphrase the generated headline, subtitle, perCard, nextStep, keyMessage, interpretation, or conclusion.
 - TONE: Write like you're texting a close friend who reads patterns and energy — never as a judge declaring an absolute truth. In Thai, use casual language (ลอง, เวิร์ค, ปัง, เน้น, จัดเลย). AVOID formal/translated phrasing (ฉันรู้สึกว่า, การรักษาความยุติธรรม, ประสบความสำเร็จ, สะท้อนกลับมา).`,

--- a/components/chat/horoscope-reading-tabs.tsx
+++ b/components/chat/horoscope-reading-tabs.tsx
@@ -83,7 +83,7 @@ export default function HoroscopeReadingTabs({
 
     const summary = getOverviewSummary(message)
     const suggestions = Array.isArray(message.followUpSuggestions)
-        ? message.followUpSuggestions
+        ? message.followUpSuggestions.slice(0, 4)
         : []
     const aliases = privacyAliases ?? []
     const relevanceStats = useMemo(

--- a/components/chat/session.tsx
+++ b/components/chat/session.tsx
@@ -287,19 +287,30 @@ function arePerCardEqual(
 }
 
 /**
- * The new schema requires exactly 2 follow-up suggestions. Old saved sessions
- * may have stored 3-4. On initial hydration we drop stale lists so the next
- * regenerate call repopulates exactly two.
+ * Follow-up chips: keep 2–4 trimmed strings; drop singletons or empty lists;
+ * trim lists longer than 4. Supports legacy tarot (2) and current 3–4 prompts.
  */
 function normalizeRestoredMessages(messages: ChatMessage[]): ChatMessage[] {
     return messages.map((m) => {
-        if (
-            Array.isArray(m.followUpSuggestions) &&
-            m.followUpSuggestions.length !== 2
-        ) {
+        if (!Array.isArray(m.followUpSuggestions)) return m
+        const cleaned = m.followUpSuggestions
+            .map((s) => (typeof s === "string" ? s.trim() : ""))
+            .filter(Boolean)
+        if (cleaned.length === 0) {
             return { ...m, followUpSuggestions: undefined }
         }
-        return m
+        if (cleaned.length === 1) {
+            return { ...m, followUpSuggestions: undefined }
+        }
+        const capped =
+            cleaned.length > 4 ? cleaned.slice(0, 4) : cleaned
+        if (
+            capped.length === m.followUpSuggestions.length &&
+            capped.every((s, i) => s === m.followUpSuggestions![i])
+        ) {
+            return m
+        }
+        return { ...m, followUpSuggestions: capped }
     })
 }
 
@@ -640,7 +651,7 @@ export default function ChatSession({
                                       typeof s === "string" ? s.trim() : "",
                                   )
                                   .filter(Boolean)
-                                  .slice(0, 2),
+                                  .slice(0, 4),
                               followUpLoading: false,
                           }
                         : m,
@@ -770,7 +781,7 @@ export default function ChatSession({
                     (s): s is string =>
                         typeof s === "string" && s.trim().length > 0,
                 ) ?? []
-            ).slice(0, 5)
+            ).slice(0, 4)
             const refetchSystem = horoscopeRefetchSystemRef.current
             setMessages((prev) =>
                 prev.map((m) => {
@@ -945,7 +956,7 @@ export default function ChatSession({
             interpretationObject.suggestions
                 ?.map((s) => (typeof s === "string" ? s.trim() : ""))
                 .filter(Boolean)
-                .slice(0, 2) ?? undefined
+                .slice(0, 4) ?? undefined
         const perCard = normalizeStreamedPerCard(interpretationObject.perCard)
         setMessages((prev) => {
             const m = prev.find((x) => x.id === lid)
@@ -1005,7 +1016,7 @@ export default function ChatSession({
             horoscopeObject.suggestions
                 ?.map((s) => (typeof s === "string" ? s.trim() : ""))
                 .filter(Boolean)
-                .slice(0, 5) ?? undefined
+                .slice(0, 4) ?? undefined
         const streamedInterpretation =
             horoscopeObject.interpretation ?? undefined
         const streamedAspectInsights = normalizeAspectInsights(
@@ -1116,7 +1127,7 @@ export default function ChatSession({
             interpretationObject?.suggestions
                 ?.map((s) => (typeof s === "string" ? s.trim() : ""))
                 .filter(Boolean)
-                .slice(0, 2) ?? undefined
+                .slice(0, 4) ?? undefined
         const perCard = normalizeStreamedPerCard(interpretationObject?.perCard)
 
         setMessages((prev) =>
@@ -1169,7 +1180,7 @@ export default function ChatSession({
             horoscopeObject?.suggestions
                 ?.map((s) => (typeof s === "string" ? s.trim() : ""))
                 .filter(Boolean)
-                .slice(0, 5) ?? undefined
+                .slice(0, 4) ?? undefined
         const streamedAspectInsights = normalizeAspectInsights(
             horoscopeObject?.aspectInsights,
         )
@@ -3862,7 +3873,10 @@ export default function ChatSession({
                     !isHoroscopeIntakeActive && composerFollowUpHost
                         ? {
                               messageId: composerFollowUpHost.id,
-                              items: composerFollowUpHost.followUpSuggestions!,
+                              items: composerFollowUpHost.followUpSuggestions!.slice(
+                                  0,
+                                  4,
+                              ),
                               onSelect: (text: string) => {
                                   applySuggestedQuestion(unmask(text))
                               },

--- a/components/chat/tarot-interpretation.tsx
+++ b/components/chat/tarot-interpretation.tsx
@@ -143,7 +143,7 @@ export type TarotAssistantInterpretationProps = {
 /**
  * Tarot card hero + AI interpretation (box variant): headline/subtitle box,
  * fanned hero card with active-card sync, per-card chip list + soft next step,
- * exactly two suggestion rows. Internal card markup (number badge, tag label,
+ * up to four follow-up suggestion chips. Internal card markup (number badge, tag label,
  * name pill, italic quote) is preserved byte-for-byte; only the layout
  * wrappers around it change.
  */
@@ -276,7 +276,7 @@ export function TarotAssistantInterpretation({
             : ""
 
     const suggestionsToRender = Array.isArray(message.followUpSuggestions)
-        ? message.followUpSuggestions.slice(0, 2)
+        ? message.followUpSuggestions.slice(0, 4)
         : []
 
     return (
@@ -667,10 +667,7 @@ export function TarotAssistantInterpretation({
                             </div>
                         )}
                     </div>
-                    {/* D. Suggestions: exactly 2 rows, full-width pills with
-                        a right-pointing arrow. Falls back to legacy chip wrap
-                        when nextStep is missing (so old messages keep their
-                        previous look). */}
+                    {/* D. Suggestions: compact rows (up to 4); composer may host these instead. */}
                     {(message.followUpConclusion ||
                         (!hideFollowUpSuggestions &&
                             suggestionsToRender.length > 0)) && (

--- a/components/question-input.tsx
+++ b/components/question-input.tsx
@@ -1,7 +1,11 @@
 "use client"
 
 import { useEffect, useState, type RefObject } from "react"
-import { ChevronRight, Send, Square } from "lucide-react"
+import { Send, Square } from "lucide-react"
+import { Swiper, SwiperSlide } from "swiper/react"
+import { FreeMode, Mousewheel } from "swiper/modules"
+import "swiper/css"
+import "swiper/css/free-mode"
 import { Button } from "./ui/button"
 import { Label } from "./ui/label"
 import { useRouter } from "next/navigation"
@@ -24,6 +28,9 @@ const INPUT_BORDER_BY_MODE: Record<InterpretationMode, string> = {
     horoscope:
         "border-blue-400/30 focus:border-blue-400/60 focus:ring-blue-400/30",
 }
+
+const followUpChipClass =
+    "swiper-no-swiping inline-flex max-w-[min(92vw,20rem)] shrink-0 items-center whitespace-nowrap rounded-full border border-white/12 bg-white/5 px-3 py-1.5 text-left text-xs leading-tight text-white/80 transition-colors hover:border-white/28 hover:bg-white/10 hover:text-white cursor-pointer"
 
 const INPUT_GLOW_BY_MODE: Record<InterpretationMode, string> = {
     auto: "shadow-[0_10px_30px_-10px_rgba(56,189,248,0.35)]",
@@ -222,29 +229,50 @@ export default function QuestionInput({
 
     const aliases = composerFollowUps?.privacyAliases ?? []
 
+    const followUpItems =
+        composerFollowUps && composerFollowUps.items.length > 0
+            ? composerFollowUps.items.slice(0, 4)
+            : []
+
     const followUpRow =
-        composerFollowUps && composerFollowUps.items.length > 0 ? (
-            <div className='w-full space-y-2'>
-                {composerFollowUps.items.map((s) => (
-                    <button
-                        key={`${composerFollowUps.messageId}-${s}`}
-                        type='button'
-                        onClick={() => composerFollowUps.onSelect(s)}
-                        className='group flex w-full items-center justify-between gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2.5 text-left text-sm text-white/80 transition hover:bg-white/10 hover:text-white'
+        composerFollowUps && followUpItems.length > 0 ? (
+            <Swiper
+                modules={[FreeMode, Mousewheel]}
+                noSwiping
+                freeMode={{
+                    enabled: true,
+                    momentum: true,
+                    sticky: false,
+                }}
+                mousewheel={{
+                    forceToAxis: true,
+                    releaseOnEdges: true,
+                    sensitivity: 1,
+                }}
+                slidesPerView='auto'
+                spaceBetween={8}
+                className='composer-follow-up-swiper w-full !overflow-visible'
+            >
+                {followUpItems.map((s, idx) => (
+                    <SwiperSlide
+                        key={`${composerFollowUps.messageId}-fu-${idx}`}
+                        className='!w-auto !flex-shrink-0 min-w-0'
                     >
-                        <span className='min-w-0 flex-1 truncate'>
-                            <PrivacyHighlightedText
-                                text={s}
-                                aliases={aliases}
-                            />
-                        </span>
-                        <ChevronRight
-                            aria-hidden
-                            className='h-4 w-4 shrink-0 text-white/45 transition group-hover:translate-x-0.5 group-hover:text-white/80'
-                        />
-                    </button>
+                        <button
+                            type='button'
+                            onClick={() => composerFollowUps.onSelect(s)}
+                            className={followUpChipClass}
+                        >
+                            <span className='block max-w-[min(92vw,20rem)] truncate'>
+                                <PrivacyHighlightedText
+                                    text={s}
+                                    aliases={aliases}
+                                />
+                            </span>
+                        </button>
+                    </SwiperSlide>
                 ))}
-            </div>
+            </Swiper>
         ) : null
 
     const inputContent = (

--- a/lib/astrology/schema.ts
+++ b/lib/astrology/schema.ts
@@ -53,10 +53,10 @@ export const horoscopeInterpretationSchema = z.object({
         ),
     suggestions: z
         .array(z.string())
-        .max(5)
+        .max(4)
         .default([])
         .describe(
-            "Up to 5 concise, specific follow-up questions the user could ask next. Write as user questions.",
+            "3–4 very short, casual follow-up prompts the user might ask next (single line each; conversational, not textbook). Write in the same language as the question.",
         ),
     relevance: z
         .array(

--- a/lib/prompts/index.ts
+++ b/lib/prompts/index.ts
@@ -402,7 +402,7 @@ ${question}
 - intensity: exactly one of "low", "medium", or "high". Use "high" only for the 1-2 strongest aspects most relevant to the question. Use "medium" for supporting aspects. Use "low" for subtle or background influences.
 - interpretation: 4-8 short sentences answering the question.
 - conclusion: A short, calming wrap-up that concludes the reading without sounding like a tagline.
-- suggestions: 3-5 concise follow-up questions the user could ask next. Write as user questions (e.g., "How should I handle this energy in my work life?").
+- suggestions: EXACTLY 3–4 very short, casual follow-up prompts the user could ask next (single line each; conversational tone, not long formal questions).
 - relevance: an array of up to 5 dominant life-areas that this reading actually covers, used to render a proportional relevance bar above the answer.
 - relevance items must contain { label, pct } only. Integer pcts MUST sum to exactly 100. Sort the array descending by pct.
 - relevance.label MUST be one of the canonical domains, written in the SAME language as the output: Career/การงาน, Finance/การเงิน, Love/ความรัก, Family/ครอบครัว, Health/สุขภาพ, Relationships/ความสัมพันธ์, Education/การศึกษา, Travel/การเดินทาง, Luck/โชคลาภ, Spirituality/จิตวิญญาณ, Reputation/ชื่อเสียง, Caution/คำเตือน. Do NOT invent new labels.

--- a/lib/prompts/prompts-rules.ts
+++ b/lib/prompts/prompts-rules.ts
@@ -112,7 +112,7 @@ Return valid JSON only. CRITICAL streaming order: cardInsights → headline → 
   "interpretation": "Back-compat. Set this to perCard[].sentence joined together as one short paragraph. Do not invent new content.",
   "nextStep": "A soft suggestion. MUST start with a non-commanding verb (ลอง / อาจ / try / consider / maybe). NEVER start with ต้อง / ควร framed as command / must / should.",
   "conclusion": "Back-compat. Set this equal to nextStep. Do not invent new content.",
-  "suggestions": ["Follow-up 1", "Follow-up 2"]
+  "suggestions": ["Short casual prompt 1", "Short casual prompt 2", "Short casual prompt 3"]
 }
 </output_schema>
 
@@ -161,10 +161,10 @@ Return valid JSON only. CRITICAL streaming order: cardInsights → headline → 
 </next_step_rules>
 
 <suggestion_rules>
-- Return EXACTLY 2 suggestions — never 1, never 3+.
-- The two suggestions MUST be distinctly different angles. They must differ in topic, perspective, or scope — not be paraphrases or near-rephrasings of each other.
-- Write each suggestion as a natural real-life follow-up question the user could genuinely ask next.
-- Keep suggestions generic enough to stand on their own — do NOT depend on the exact wording of the generated headline/subtitle/perCard/nextStep, and do NOT quote or closely paraphrase any generated text.
+- Return EXACTLY 3–4 suggestions — never fewer than 3, never more than 4.
+- Each one must be VERY short (aim ≤8 Thai words or ≤6 English words), single line, casual human phrasing — like quick text ideas, not essay prompts.
+- All suggestions MUST be distinctly different angles (topic, perspective, or scope) — not paraphrases of each other.
+- Keep them generic enough to stand on their own — do NOT depend on the exact wording of the generated headline/subtitle/perCard/nextStep, and do NOT quote or closely paraphrase any generated text.
 - Same language as the user's question.
 </suggestion_rules>
 

--- a/lib/tarot/schema.ts
+++ b/lib/tarot/schema.ts
@@ -6,7 +6,7 @@ import { z } from "zod"
  *   cardInsights → headline → subtitle → keyMessage → perCard → keywords →
  *   interpretation → nextStep → conclusion → suggestions
  *
- * The "new" fields (headline/subtitle/perCard/nextStep + 2-only suggestions)
+ * The "new" fields (headline/subtitle/perCard/nextStep + 3–4 short suggestions)
  * power the refreshed chat-session result UI. The "legacy" fields
  * (cardInsights/keyMessage/keywords/interpretation/conclusion) are still
  * populated by the model so the legacy `/tarot` page and the DB-backed
@@ -73,9 +73,10 @@ export const tarotInterpretationSchema = z.object({
         ),
     suggestions: z
         .array(z.string())
-        .length(2)
+        .min(3)
+        .max(4)
         .describe(
-            "EXACTLY 2 follow-up questions the user could naturally ask next. The two MUST be distinctly different angles — different topic, perspective, or scope — never paraphrases of each other. Write as natural user questions. Do NOT depend on the exact wording of the generated headline/subtitle/perCard/nextStep. Same language as the user's question.",
+            "EXACTLY 3–4 very short follow-up prompts the user might tap next. Sound like a real person texting (casual, plain language) — not formal essay questions. Each item MUST be a single line, ≤8 Thai words or ≤6 English words when possible. All four MUST differ in angle (topic, scope, or perspective) — no near-duplicates. Do NOT quote or lean on the exact wording of headline/subtitle/perCard/nextStep. Same language as the user's question.",
         ),
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change tightens how AI follow-up suggestions behave and how they appear above the home/chat composer.

## What changed

- **Copy and model rules**: Tarot interpretation now asks the model for **exactly 3–4** very short, casual, one-line prompts (friend-text tone, not long formal questions), with distinct angles. Horoscope prompts and the shared horoscope schema now target **up to four** suggestions with the same tone guidance.
- **Composer UI**: When the last assistant message exposes follow-ups, they render in a **horizontal Swiper** row (same interaction pattern as `ActionTrigger`) with compact pill chips instead of stacked full-width rows.
- **Session handling**: Streaming and finalize paths **cap suggestions at four**. Restored sessions keep trimmed lists of **two to four** items (singletons and empty lists are cleared; lists longer than four are truncated).

## Notes

- Legacy saved readings that still have **two** tarot suggestions remain valid until the user gets a new reading with the updated schema.
- Inline tarot/horoscope suggestion UIs now respect the same **four-item** cap for consistency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3a5fcc2-ac07-4f1e-b678-3748babfd637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3a5fcc2-ac07-4f1e-b678-3748babfd637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

