### PR TITLE
fix(tarot): privacy chips for detailedHtml and card insights

### DIFF
--- a/components/chat/privacy-detailed-html.tsx
+++ b/components/chat/privacy-detailed-html.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import {
+    createElement,
+    useLayoutEffect,
+    useState,
+    type ReactNode,
+} from "react"
+import { PrivacyHighlightedText } from "@/components/chat/privacy-highlighted-user-text"
+import { sanitizeDetailedHtml } from "@/lib/tarot/sanitize-html"
+import type { PromptAliasEntry } from "@/lib/privacy/prompt-redaction"
+
+const VOID_TAGS = new Set(["br"])
+
+function childNodesToReact(
+    parent: ParentNode,
+    aliases: PromptAliasEntry[],
+    path: string,
+): ReactNode[] {
+    const out: ReactNode[] = []
+    parent.childNodes.forEach((node, idx) => {
+        const key = `${path}.${idx}`
+        if (node.nodeType === Node.TEXT_NODE) {
+            const text = node.textContent ?? ""
+            if (!text) return
+            out.push(
+                createElement(PrivacyHighlightedText, {
+                    key,
+                    text,
+                    aliases,
+                    supportMarkdown: false,
+                }),
+            )
+            return
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) return
+        const el = node as HTMLElement
+        const tag = el.tagName.toLowerCase()
+        if (VOID_TAGS.has(tag)) {
+            out.push(createElement(tag, { key }))
+            return
+        }
+        const inner = childNodesToReact(el, aliases, key)
+        const props: {
+            key: string
+            className?: string
+            children?: ReactNode | ReactNode[]
+        } = { key }
+        if (tag === "span" && el.classList.contains("highlight-gold")) {
+            props.className = "highlight-gold"
+        }
+        if (inner.length > 0) {
+            props.children = inner
+        }
+        out.push(
+            createElement(tag as keyof JSX.IntrinsicElements, props),
+        )
+    })
+    return out
+}
+
+type PrivacyDetailedHtmlProps = {
+    html: string | null | undefined
+    aliases: PromptAliasEntry[]
+    className?: string
+}
+
+/**
+ * Renders AI `detailedHtml` like `dangerouslySetInnerHTML` would, but runs each
+ * text node through {@link PrivacyHighlightedText} so `[Person_0]`-style
+ * tokens become the same emerald lock chips as the rest of the tarot UI.
+ *
+ * Uses `DOMParser` after {@link sanitizeDetailedHtml}; parsing runs in
+ * `useLayoutEffect` so the first painted frame matches SSR (empty shell) then
+ * updates before paint on the client.
+ */
+export function PrivacyDetailedHtml({
+    html,
+    aliases,
+    className,
+}: PrivacyDetailedHtmlProps) {
+    const safe = sanitizeDetailedHtml(html)
+    const [nodes, setNodes] = useState<ReactNode[] | null>(null)
+
+    useLayoutEffect(() => {
+        if (!safe) {
+            setNodes(null)
+            return
+        }
+        const wrapped = `<div id="privacy-detailed-html-root">${safe}</div>`
+        const doc = new DOMParser().parseFromString(wrapped, "text/html")
+        const root = doc.getElementById("privacy-detailed-html-root")
+        if (!root) {
+            setNodes(null)
+            return
+        }
+        setNodes(childNodesToReact(root, aliases, "dh"))
+    }, [safe, aliases])
+
+    if (!safe) return null
+
+    return (
+        <div className={className}>
+            {nodes !== null && nodes.length > 0 ? nodes : null}
+        </div>
+    )
+}

--- a/components/chat/privacy-detailed-html.tsx
+++ b/components/chat/privacy-detailed-html.tsx
@@ -10,7 +10,63 @@ import { PrivacyHighlightedText } from "@/components/chat/privacy-highlighted-us
 import { sanitizeDetailedHtml } from "@/lib/tarot/sanitize-html"
 import type { PromptAliasEntry } from "@/lib/privacy/prompt-redaction"
 
-const VOID_TAGS = new Set(["br"])
+/** Mirrors allowed tags in `lib/tarot/sanitize-html.ts` (excluding `br`). */
+type DetailedHtmlBlockTag =
+    | "p"
+    | "strong"
+    | "em"
+    | "b"
+    | "i"
+    | "ul"
+    | "ol"
+    | "li"
+    | "span"
+
+const BLOCK_TAGS: readonly DetailedHtmlBlockTag[] = [
+    "p",
+    "strong",
+    "em",
+    "b",
+    "i",
+    "ul",
+    "ol",
+    "li",
+    "span",
+]
+
+function isDetailedHtmlBlockTag(s: string): s is DetailedHtmlBlockTag {
+    return (BLOCK_TAGS as readonly string[]).includes(s)
+}
+
+function createDetailedHtmlBlockElement(
+    tag: DetailedHtmlBlockTag,
+    props: {
+        key: string
+        className?: string
+        children?: ReactNode | ReactNode[]
+    },
+): ReactNode {
+    switch (tag) {
+        case "p":
+            return createElement("p", props)
+        case "strong":
+            return createElement("strong", props)
+        case "em":
+            return createElement("em", props)
+        case "b":
+            return createElement("b", props)
+        case "i":
+            return createElement("i", props)
+        case "ul":
+            return createElement("ul", props)
+        case "ol":
+            return createElement("ol", props)
+        case "li":
+            return createElement("li", props)
+        case "span":
+            return createElement("span", props)
+    }
+}
 
 function childNodesToReact(
     parent: ParentNode,
@@ -36,8 +92,12 @@ function childNodesToReact(
         if (node.nodeType !== Node.ELEMENT_NODE) return
         const el = node as HTMLElement
         const tag = el.tagName.toLowerCase()
-        if (VOID_TAGS.has(tag)) {
-            out.push(createElement(tag, { key }))
+        if (tag === "br") {
+            out.push(createElement("br", { key }))
+            return
+        }
+        if (!isDetailedHtmlBlockTag(tag)) {
+            out.push(...childNodesToReact(el, aliases, key))
             return
         }
         const inner = childNodesToReact(el, aliases, key)
@@ -52,9 +112,7 @@ function childNodesToReact(
         if (inner.length > 0) {
             props.children = inner
         }
-        out.push(
-            createElement(tag as keyof JSX.IntrinsicElements, props),
-        )
+        out.push(createDetailedHtmlBlockElement(tag, props))
     })
     return out
 }

--- a/components/chat/tarot-interpretation.tsx
+++ b/components/chat/tarot-interpretation.tsx
@@ -7,12 +7,12 @@ import ShareSection from "@/components/tarot/interpretation/share"
 import { InterpretationHeaderBar } from "@/components/chat/interpretation-header-bar"
 import type { ChatMessage } from "@/components/chat/types"
 import { LoadingDotsText } from "@/components/chat/loading-dots-text"
+import { PrivacyDetailedHtml } from "@/components/chat/privacy-detailed-html"
 import { PrivacyHighlightedText } from "@/components/chat/privacy-highlighted-user-text"
 import {
     applyAliasesToText,
     type PromptAliasEntry,
 } from "@/lib/privacy/prompt-redaction"
-import { sanitizeDetailedHtml } from "@/lib/tarot/sanitize-html"
 import { useTranslations } from "next-intl"
 import { Loader2, Share, Sparkles } from "lucide-react"
 
@@ -115,6 +115,9 @@ function formatInterpretationBody(text: string, question?: string): string[] {
     return cleanedParagraphs.slice(0, 1)
 }
 
+/** Stable fallback so `privacyAliases ?? …` does not allocate a new `[]` each render. */
+const EMPTY_PRIVACY_ALIASES: PromptAliasEntry[] = []
+
 export type TarotAssistantInterpretationProps = {
     message: ChatMessage
     messages: ChatMessage[]
@@ -160,7 +163,7 @@ export function TarotAssistantInterpretation({
 }: TarotAssistantInterpretationProps) {
     const tReading = useTranslations("ReadingPage.interpretation")
 
-    const aliases = privacyAliases ?? []
+    const aliases = privacyAliases ?? EMPTY_PRIVACY_ALIASES
     const rawMessageText = message.text || ""
     const unmaskedMessageText = unmask(rawMessageText)
     const unmaskedKeyMessage = unmask(message.keyMessage)
@@ -250,12 +253,8 @@ export function TarotAssistantInterpretation({
     }, [message.perCard])
     const hasPerCard = perCardItems.length > 0
 
-    // "Detailed" key-takeaways block — paragraphs only, sanitized to a tiny
-    // tag whitelist. Rendered between the headline/subtitle box and the hero
-    // card area so it sits above the "card say" insight quotes.
-    const safeDetailedHtml = useMemo(
-        () => sanitizeDetailedHtml(message.detailedHtml),
-        [message.detailedHtml],
+    const hasDetailedHtmlBlock = Boolean(
+        message.detailedHtml && message.detailedHtml.trim(),
     )
     const detailedLabel = (() => {
         try {
@@ -388,9 +387,19 @@ export function TarotAssistantInterpretation({
                                             />
                                         </span>
                                     ) : (
-                                        unmask(
-                                            message.insights?.[safeActiveIndex],
-                                        ) || `${consultingBase}...`
+                                        <PrivacyHighlightedText
+                                            text={
+                                                message.insights?.[
+                                                    safeActiveIndex
+                                                ]?.trim()
+                                                    ? message.insights[
+                                                          safeActiveIndex
+                                                      ]!
+                                                    : `${consultingBase}...`
+                                            }
+                                            aliases={aliases}
+                                            supportMarkdown={false}
+                                        />
                                     )}
                                     &rdquo;
                                 </p>
@@ -562,7 +571,7 @@ export function TarotAssistantInterpretation({
                                         sits directly BELOW the key message
                                         and ABOVE the perCard breakdown,
                                         with its own small uppercase label. */}
-                                    {safeDetailedHtml && (
+                                    {hasDetailedHtmlBlock && (
                                         <div className='rounded-2xl border border-yellow-400/15 bg-gradient-to-br from-yellow-500/[0.04] via-white/[0.03] to-yellow-500/[0.04] p-5 shadow-lg animate-fade-in relative overflow-hidden'>
                                             <div
                                                 aria-hidden
@@ -574,11 +583,10 @@ export function TarotAssistantInterpretation({
                                                     {detailedLabel}
                                                 </p>
                                             </div>
-                                            <div
+                                            <PrivacyDetailedHtml
+                                                html={message.detailedHtml}
+                                                aliases={aliases}
                                                 className='tarot-detailed-html text-white/90 leading-relaxed relative z-10'
-                                                dangerouslySetInnerHTML={{
-                                                    __html: safeDetailedHtml,
-                                                }}
                                             />
                                         </div>
                                     )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Detailed** tarot block used `dangerouslySetInnerHTML` after DOMPurify, so AI text that contained privacy placeholders (for example `[Person_0]`) never went through `PrivacyHighlightedText`. Those tokens appeared verbatim while headline, subtitle, per-card lines, next step, legacy body, and follow-up conclusion already showed the emerald lock chips.

## Changes

- Add `PrivacyDetailedHtml`, which sanitizes with `sanitizeDetailedHtml`, parses the fragment with `DOMParser`, and wraps each text node in `PrivacyHighlightedText` so placeholders match the rest of the interpretation UI.
- Use an explicit switch on allowed block tags (plus `br`) for `createElement` so TypeScript accepts the build under React 19 / current `@types/react` (avoids `keyof JSX.IntrinsicElements` including `number` / `symbol`).
- Use a module-level empty alias array for `privacyAliases ?? …` so a new `[]` is not allocated every render when aliases are undefined (which would retrigger layout parsing every frame).
- Render hero **card insights** quotes through `PrivacyHighlightedText` instead of plain `unmask`, so the same masking behavior applies there too.

## Verification

- `detailedHtml`: chips for all placeholder types supported by `PrivacyHighlightedText` / session aliases.
- Other box-variant sections in `TarotAssistantInterpretation` already used `PrivacyHighlightedText` (headline, subtitle, perCard, nextStep, legacy paragraphs, followUpConclusion) or now align (insights, detailed HTML).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91209cd1-042c-48dc-b085-a8b8605e51f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91209cd1-042c-48dc-b085-a8b8605e51f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

