### PR TITLE
Break tarot interpretation wall-of-text into rhythm blocks

### DIFF
--- a/app/[locale]/share/[id]/shared-tarot-view.tsx
+++ b/app/[locale]/share/[id]/shared-tarot-view.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image"
 import { Badge } from "@/components/ui/badge"
 import { Sparkles } from "lucide-react"
+import InterpretationProse from "@/components/tarot/interpretation/prose"
 
 type CardFull = {
     id: number
@@ -179,9 +180,42 @@ export default function SharedTarotView({ data }: { data: SharedTarotData }) {
                             </p>
                         </div>
                     </div>
-                    <div className='text-white/90 leading-relaxed whitespace-pre-wrap'>
-                        {data.interpretation}
-                    </div>
+                    {(() => {
+                        const parts = (data.interpretation ?? "").split("\n\n")
+                        const keywords = parts[0] ?? ""
+                        const body = parts.slice(1).join("\n\n").trim()
+                        const looksLikeKeywords =
+                            keywords.length > 0 &&
+                            keywords.length < 120 &&
+                            keywords.includes(",") &&
+                            body.length > 0
+                        const keywordList = looksLikeKeywords
+                            ? keywords.split(",").map((k) => k.trim()).filter(Boolean)
+                            : []
+                        const proseText = looksLikeKeywords
+                            ? body
+                            : data.interpretation
+                        return (
+                            <>
+                                {keywordList.length > 0 && (
+                                    <div className='flex flex-wrap gap-2'>
+                                        {keywordList.map((k, i) => (
+                                            <span
+                                                key={i}
+                                                className='px-3 py-1 text-xs font-medium rounded-full bg-white/10 text-white border border-white/20'
+                                            >
+                                                {k.charAt(0).toUpperCase() + k.slice(1)}
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+                                <InterpretationProse
+                                    text={proseText}
+                                    variant='muted'
+                                />
+                            </>
+                        )
+                    })()}
                 </div>
 
                 {/* Conclusion */}

--- a/components/tarot/interpretation/index.tsx
+++ b/components/tarot/interpretation/index.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import ShareSection from "./share"
 import ActionSection from "./action"
+import InterpretationProse from "./prose"
 //
 import BrandLoader from "@/components/brand-loader"
 import HardStarConsent from "@/components/hard-star-consent"
@@ -550,7 +551,11 @@ export default function Interpretation({
                                                             )}
                                                     </div>
                                                 )}
-                                                {content}
+                                                {content && (
+                                                    <InterpretationProse
+                                                        text={content}
+                                                    />
+                                                )}
 
                                                 {/* Disclaimer at the bottom */}
                                                 <div className='mt-8 pt-6 border-t border-white/5'>
@@ -606,7 +611,13 @@ export default function Interpretation({
                                                             )}
                                                     </div>
                                                 )}
-                                                {displayObject.interpretation}
+                                                {displayObject.interpretation && (
+                                                    <InterpretationProse
+                                                        text={
+                                                            displayObject.interpretation
+                                                        }
+                                                    />
+                                                )}
 
                                                 {/* Disclaimer at the bottom (while generating) */}
                                                 <div className='mt-8 pt-6 border-t border-white/5 opacity-50'>

--- a/components/tarot/interpretation/prose.tsx
+++ b/components/tarot/interpretation/prose.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+interface InterpretationProseProps {
+    text: string
+    className?: string
+    /**
+     * When true, applies the muted/translucent palette used inside the share view.
+     * When false (default), uses the foreground palette used in the main reading card.
+     */
+    variant?: "default" | "muted"
+}
+
+/**
+ * Splits the interpretation text into paragraph chunks. We rely on the model's
+ * natural paragraph breaks (\n\n) so we don't have to introspect language-specific
+ * sentence boundaries (Thai, for example, doesn't use full stops the way English does).
+ * If no paragraph breaks are present we fall back to a single chunk so partial /
+ * streaming text still renders.
+ */
+function splitIntoParagraphs(text: string): string[] {
+    const trimmed = text.trim()
+    if (!trimmed) return []
+    const paragraphs = trimmed
+        .split(/\n{2,}/)
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0)
+    return paragraphs.length > 0 ? paragraphs : [trimmed]
+}
+
+export default function InterpretationProse({
+    text,
+    className,
+    variant = "default",
+}: InterpretationProseProps) {
+    const paragraphs = splitIntoParagraphs(text)
+
+    if (paragraphs.length === 0) return null
+
+    const textColor =
+        variant === "muted" ? "text-white/85" : "text-foreground/90"
+
+    return (
+        <div className={cn("space-y-5", className)}>
+            {paragraphs.map((paragraph, index) => (
+                <div
+                    key={index}
+                    className='relative flex gap-3 rounded-r-md border-l-2 border-primary/40 bg-primary/[0.04] py-2 pl-4 pr-3'
+                >
+                    <span
+                        aria-hidden
+                        className='select-none text-primary/60 leading-[1.6] text-sm'
+                    >
+                        ✦
+                    </span>
+                    <p
+                        className={cn(
+                            "flex-1 whitespace-pre-wrap leading-relaxed",
+                            textColor,
+                        )}
+                    >
+                        {paragraph}
+                    </p>
+                </div>
+            ))}
+        </div>
+    )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The tarot interpretation panel renders the AI-generated reading as a raw multi-paragraph string inside a single `whitespace-pre-wrap` div. Paragraphs collapse together visually and the result reads as one dense wall of text, especially on mobile.

This PR makes the prose easier to scan **without breaking the storytelling voice** the prompt and schema are tuned for.

## Why not full bullets

The schema in `lib/tarot/schema.ts` explicitly asks the model for "a warm and conversational tone" 6–12 sentence reading, and the prompt forbids markdown. Hard bullet points would:

- Clash with the mystical/divinatory product feel
- Be redundant with the punchy per-card `cardInsights` chips already rendered next to each card
- Require invasive changes (schema, prompt, DB write path, share view, version history) and would be fragile for languages like Thai that don't reliably use sentence-ending punctuation

The chosen middle ground keeps prose-level voice while giving the reader visual rhythm and scan-ability.

## Changes

- New `components/tarot/interpretation/prose.tsx`
  - Splits the interpretation on natural paragraph breaks (`\n{2,}`) — the model already emits these, no prompt change required
  - Renders each paragraph in its own block with a left accent bar (`border-l-2 border-primary/40`), a subtle primary-tinted background, comfortable padding, and a leading `✦` glyph
  - Gracefully handles partial / streaming text (falls back to a single chunk if no paragraph break is present yet)
  - `variant="muted"` switches palette for the share/public view
- `components/tarot/interpretation/index.tsx` — uses `InterpretationProse` for both the saved-interpretation branch and the streaming branch; keeps keyword pills above unchanged
- `app/[locale]/share/[id]/shared-tarot-view.tsx` — uses `InterpretationProse` and also splits the stored `${keywords}\n\n${interpretation}` payload so keywords render as pills (matching the main view) instead of as a raw CSV line

## Risk

Low. Pure UI change. No schema, prompt, API, or DB changes. Saved readings keep working because the stored format is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8421d06a-a855-4f7f-8a4a-b138953ac56b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8421d06a-a855-4f7f-8a4a-b138953ac56b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

