### PR TITLE
feat(chat): support mode with inline tool blocks for product topics

### DIFF
--- a/app/api/chat/respond/route.ts
+++ b/app/api/chat/respond/route.ts
@@ -9,8 +9,9 @@ const MODEL = "deepseek/deepseek-v3.2"
 
 const requestSchema = z.object({
     question: z.string().trim().min(1),
-    type: z.enum(["chat", "draw", "horoscope"]),
+    type: z.enum(["chat", "draw", "horoscope", "support"]),
     isFollowUp: z.boolean().optional(),
+    supportTopic: z.string().nullable().optional(),
     history: z
         .array(
             z.object({
@@ -57,6 +58,18 @@ If mode is horoscope:
 - It MUST NOT exceed 60 characters.
 - Invite them to begin the horoscope reading naturally.
 - Do not ask for birth date or birth time.
+
+If mode is support:
+- The user is asking about the AskingFate website / product, NOT for a reading.
+- An inline tool block (pricing, contact form, tarot card hero, article preview, etc.) will be rendered for them automatically below your reply.
+- Return 1-2 short sentences (max 220 characters total) that ACKNOWLEDGE the topic and invite them to explore the block below.
+- Do NOT repeat all the details that will be in the block (e.g. plan prices, full FAQ answers). Stay brief and oracle-like.
+- Do NOT include URLs, markdown links, or asterisks. Plain text only.
+- Examples:
+  - pricing: "Our plans live below. Tap one to continue to checkout."
+  - contact: "Send your message in the form below — we read every line."
+  - tarot-card (seven of cups): "The Seven of Cups speaks of choices and illusion. Its full meaning waits below."
+  - faq: "I gathered the common answers for you below."
 `
 
 function detectQuestionLanguage(text: string): string {
@@ -72,6 +85,7 @@ function getChatResponsePrompt({
     question,
     type,
     isFollowUp,
+    supportTopic,
     history,
     contextSummary,
     savedBirthInfo,
@@ -103,7 +117,7 @@ ${question}
 
 Response mode: ${type}
 Is follow-up: ${isFollowUp ? "yes" : "no"}
-${savedBirthBlock}
+${type === "support" && supportTopic ? `Support topic: ${supportTopic}\n` : ""}${savedBirthBlock}
 DETECTED LANGUAGE: The user's message is in ${detectedLang}. Ignore the language of conversation history.
 
 Write the user-facing response now.

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -149,10 +149,17 @@ function detectQuestionLanguage(text: string): string {
     return "English"
 }
 
-const MODE_TO_TYPE: Record<string, string> = {
+/**
+ * Maps the user-facing interpretation mode (set in the composer menu) to the
+ * decision `type` (or list of allowed types). The "chat" mode is special: it
+ * is the merged chat+support mode, so we let the classifier pick either
+ * `chat` (plain text knowledge reply) or `support` (inline tool block for
+ * product topics) instead of pinning a single type.
+ */
+const MODE_TO_TYPE: Record<string, string | string[]> = {
     tarot: "draw",
     horoscope: "horoscope",
-    chat: "chat",
+    chat: ["chat", "support"],
     support: "support",
 }
 
@@ -189,9 +196,13 @@ function getChatDecisionPrompt({
             ? MODE_TO_TYPE[interpretationMode]
             : null
 
-    const modeInstruction = forcedType
-        ? `\nThe user has locked the mode to "${forcedType}". You MUST set type to "${forcedType}". If the forced type is "draw", you must still choose the best spreadType and spreadReason.\n`
-        : ""
+    let modeInstruction = ""
+    if (Array.isArray(forcedType)) {
+        const list = forcedType.map((t) => `"${t}"`).join(" or ")
+        modeInstruction = `\nThe user has locked the mode to "${interpretationMode}". You MUST set type to ${list}. If the message is about the AskingFate website or product (pricing, contact, a specific tarot card, an article, account/settings, sign-in, etc.), choose "support" and set supportTopic (and supportCardSlug when relevant). Otherwise choose "chat" and answer as plain knowledge. Never choose "draw" or "horoscope" while this mode is active.\n`
+    } else if (forcedType) {
+        modeInstruction = `\nThe user has locked the mode to "${forcedType}". You MUST set type to "${forcedType}". If the forced type is "draw", you must still choose the best spreadType and spreadReason. If the forced type is "support", you MUST set supportTopic (and supportCardSlug when the user is asking about a specific tarot card).\n`
+    }
 
     const detectedLang = detectQuestionLanguage(question)
     const savedBirthBlock = savedBirthInfo

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -17,13 +17,14 @@ Classify the user's message into ONE type:
 chat
 draw
 horoscope
+support
 
 Definitions:
 
 chat
 - general greetings (hi, hello)
-- technical definitions of astrology/tarot
-- "Who are you?" or "What can you do?"
+- technical definitions of astrology/tarot ("what is a trine?", "what is the 7th house?")
+- "Who are you?" or "What can you do?" (only if not asking for a feature; otherwise use support)
 - (DO NOT use chat for advice, strategy, or problem-solving; use 'draw' for those)
 
 draw
@@ -36,6 +37,35 @@ horoscope
 - timing questions
 - today / tomorrow / this month / this year
 - astrology timing
+
+support
+- ANY question about the AskingFate WEBSITE / PRODUCT itself
+- pricing, plans, subscriptions, refunds, billing → supportTopic: "pricing"
+- buying / refilling / running out of stars, star packs → supportTopic: "star-packs"
+- "I want to contact support", "is there a human?", reporting a bug, complaints → supportTopic: "contact"
+- general help / troubleshooting → supportTopic: "help"
+- frequently asked questions → supportTopic: "faq"
+- "how do I use this?", "how does it work?", tutorial, getting started → supportTopic: "how-to-play"
+- account, delete account, change email, sign-out → supportTopic: "account"
+- settings, preferences, language → supportTopic: "settings"
+- privacy / PII redaction notice in chat → supportTopic: "privacy-redaction"
+- privacy policy / data → supportTopic: "privacy-policy"
+- terms of service → supportTopic: "terms-of-service"
+- referrals, inviting friends → supportTopic: "refer-a-friend"
+- sharing a reading link → supportTopic: "share-reading"
+- creating content about AskingFate for stars → supportTopic: "create-content"
+- about the company / our team → supportTopic: "about"
+- sign-in / log in → supportTopic: "sign-in"
+- sign-up / register → supportTopic: "sign-up"
+- a specific tarot card "what does the seven of cups mean?", "the fool meaning" → supportTopic: "tarot-card" and set supportCardSlug to the canonical kebab-case slug (e.g. "seven-of-cups", "the-fool", "queen-of-pentacles")
+- "show me all tarot cards", "the deck" → supportTopic: "tarot-cards-index"
+- our birth chart feature → supportTopic: "birth-chart"
+- our horoscope feature (asking ABOUT the feature, not requesting a horoscope) → supportTopic: "horoscope"
+- browsing articles or guides → supportTopic: "articles"
+
+When the message is BOTH a feature question AND a fortune-telling question, prefer "support" only if it is clearly about the product. Otherwise stick with draw/horoscope. For a real fortune question that incidentally mentions stars / pricing, still use draw.
+
+If type is "support", you MUST set supportTopic. Set supportCardSlug only for tarot-card.
 
 If type is "draw", you MUST also choose ONE tarot spread:
 
@@ -77,13 +107,16 @@ Use it to detect follow-up questions:
 Return JSON only:
 
 {
-"type":"chat"|"draw"|"horoscope",
+"type":"chat"|"draw"|"horoscope"|"support",
 "isFollowUp":true|false,
 "spreadType":"simple"|"general"|"detailed"|"expanded"|"celtic",
-"spreadReason":"short reason"
+"spreadReason":"short reason",
+"supportTopic":"pricing"|"contact"|"...",
+"supportCardSlug":"seven-of-cups"
 }
 
 If type is NOT "draw", omit spreadType and spreadReason.
+If type is NOT "support", omit supportTopic and supportCardSlug.
 
 CRITICAL LANGUAGE RULE:
 Use the user's language to help classification accuracy.
@@ -120,6 +153,7 @@ const MODE_TO_TYPE: Record<string, string> = {
     tarot: "draw",
     horoscope: "horoscope",
     chat: "chat",
+    support: "support",
 }
 
 function getChatDecisionPrompt({

--- a/components/chat/message-list.tsx
+++ b/components/chat/message-list.tsx
@@ -25,6 +25,7 @@ import RealtimePlanetaryPanel from "@/components/astrology/realtime-planetary-pa
 import AutoHeightTextarea from "@/components/ui/auto-height-textarea"
 import HoroscopeReadingTabs from "@/components/chat/horoscope-reading-tabs"
 import { TarotAssistantInterpretation } from "@/components/chat/tarot-interpretation"
+import { SupportBlock } from "@/components/chat/support/support-block"
 import {
     PrivacyHighlightedText,
     PrivacyHighlightedUserText,
@@ -1072,6 +1073,16 @@ export default function MessageList({
                                                 />
                                             )}
                                         </div>
+                                        {!message.isLoading &&
+                                            message.supportBlock && (
+                                                <div className='w-full md:max-w-[85%] animate-fade-in'>
+                                                    <SupportBlock
+                                                        payload={
+                                                            message.supportBlock
+                                                        }
+                                                    />
+                                                </div>
+                                            )}
                                     </>
                                 )}
                                 {message.role === "assistant" &&

--- a/components/chat/session.tsx
+++ b/components/chat/session.tsx
@@ -1688,14 +1688,32 @@ export default function ChatSession({
     const applyInterpretationModeOverride = useCallback(
         (decision: ChatDecision): ChatDecision => {
             if (interpretationMode === "auto") return decision
-            // Support-mode answers (pricing, contact, tarot card info, etc.)
-            // are about the product itself, not a reading. They should bypass
-            // tarot/horoscope mode locks so the user still gets the right
-            // inline tool block.
-            if (decision.type === "support") return decision
+            // The "chat" interpretation mode is the merged chat+support mode:
+            // the AI may pick either `chat` (plain knowledge answer) or
+            // `support` (inline tool block for product topics like pricing,
+            // contact, a specific tarot card, etc.). Anything else gets
+            // downgraded to `chat` so reading flows are disabled here.
             if (interpretationMode === "chat") {
-                return { ...decision, type: "chat" }
+                if (
+                    decision.type === "chat" ||
+                    decision.type === "support"
+                ) {
+                    return decision
+                }
+                return {
+                    ...decision,
+                    type: "chat",
+                    spreadType: undefined,
+                    cardCount: undefined,
+                    spreadReason: undefined,
+                    supportTopic: undefined,
+                    supportCardSlug: undefined,
+                }
             }
+            // Support-mode answers about the product itself bypass tarot /
+            // horoscope mode locks so users keep getting the right inline
+            // tool block.
+            if (decision.type === "support") return decision
             if (interpretationMode === "tarot") {
                 return { ...decision, type: "draw" }
             }

--- a/components/chat/session.tsx
+++ b/components/chat/session.tsx
@@ -87,6 +87,7 @@ import type {
 import { parseQuestionDomain } from "@/lib/chat/situation-schema"
 
 import { getTarotCardCount } from "@/lib/chat/decision-schema"
+import { buildSupportBlockFromDecision } from "@/lib/chat/support-block"
 import { useAuth } from "@/hooks/use-auth"
 import { useProfile } from "@/contexts/profile-context"
 import { supabase } from "@/lib/supabase"
@@ -1687,6 +1688,11 @@ export default function ChatSession({
     const applyInterpretationModeOverride = useCallback(
         (decision: ChatDecision): ChatDecision => {
             if (interpretationMode === "auto") return decision
+            // Support-mode answers (pricing, contact, tarot card info, etc.)
+            // are about the product itself, not a reading. They should bypass
+            // tarot/horoscope mode locks so the user still gets the right
+            // inline tool block.
+            if (decision.type === "support") return decision
             if (interpretationMode === "chat") {
                 return { ...decision, type: "chat" }
             }
@@ -2572,6 +2578,7 @@ export default function ChatSession({
             question,
             type,
             isFollowUp,
+            supportTopic,
             historyOverride,
             savedBirthInfo,
             onChunk,
@@ -2579,6 +2586,7 @@ export default function ChatSession({
             question: string
             type: ChatDecision["type"]
             isFollowUp?: boolean
+            supportTopic?: string | null
             historyOverride?: { role: string; text: string }[]
             savedBirthInfo?: string | null
             onChunk?: (text: string) => void
@@ -2602,6 +2610,7 @@ export default function ChatSession({
                     question,
                     type,
                     isFollowUp,
+                    supportTopic: supportTopic ?? undefined,
                     history,
                     savedBirthInfo: savedBirthInfo ?? undefined,
                     contextSummary: contextSummary || undefined,
@@ -2893,10 +2902,15 @@ export default function ChatSession({
                 nextDecision = normalizeDrawDecision(nextDecision)
                 flowDecision = nextDecision
                 setDecision(nextDecision)
+                const supportBlock = buildSupportBlockFromDecision(
+                    nextDecision,
+                    trimmed,
+                )
                 const assistantText = await streamAssistantResponse({
                     question: trimmed,
                     type: nextDecision.type,
                     isFollowUp: nextDecision.isFollowUp,
+                    supportTopic: supportBlock?.topic ?? null,
                     historyOverride: history,
                     savedBirthInfo,
                     onChunk: (partial) => {
@@ -2919,6 +2933,9 @@ export default function ChatSession({
                                   text: assistantText || m.text,
                                   isLoading: false,
                                   streamStopped: false,
+                                  supportTopic:
+                                      supportBlock?.topic ?? undefined,
+                                  supportBlock: supportBlock ?? undefined,
                               }
                             : m,
                     ),
@@ -3232,10 +3249,15 @@ export default function ChatSession({
                 nextDecision = normalizeDrawDecision(nextDecision)
                 flowDecision = nextDecision
                 setDecision(nextDecision)
+                const supportBlock = buildSupportBlockFromDecision(
+                    nextDecision,
+                    trimmed,
+                )
                 const assistantText = await streamAssistantResponse({
                     question: trimmed,
                     type: nextDecision.type,
                     isFollowUp: nextDecision.isFollowUp,
+                    supportTopic: supportBlock?.topic ?? null,
                     historyOverride: history,
                     savedBirthInfo,
                     onChunk: (partial) => {
@@ -3258,6 +3280,9 @@ export default function ChatSession({
                                   text: assistantText || m.text,
                                   isLoading: false,
                                   streamStopped: false,
+                                  supportTopic:
+                                      supportBlock?.topic ?? undefined,
+                                  supportBlock: supportBlock ?? undefined,
                               }
                             : m,
                     ),

--- a/components/chat/support/article-block.tsx
+++ b/components/chat/support/article-block.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import type { SupportBlockPayload } from "@/components/chat/types"
+import { PageBlock } from "./page-block"
+
+export function ArticleBlock({
+    payload,
+}: {
+    payload: Extract<SupportBlockPayload, { kind: "article" }>
+}) {
+    return <PageBlock payload={payload} ctaLabel='Read article' />
+}

--- a/components/chat/support/contact-block.tsx
+++ b/components/chat/support/contact-block.tsx
@@ -1,0 +1,234 @@
+"use client"
+
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import * as z from "zod"
+import { useTranslations } from "next-intl"
+import { toast } from "sonner"
+import { ArrowRight, Mail, Send } from "lucide-react"
+import { Link } from "@/i18n/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form"
+import { useAuth } from "@/hooks/use-auth"
+import type { SupportBlockPayload } from "@/components/chat/types"
+
+const schema = z.object({
+    name: z
+        .string()
+        .min(2, "Name must be at least 2 characters")
+        .max(50, "Name must be less than 50 characters"),
+    email: z.string().email("Please enter a valid email address"),
+    subject: z
+        .string()
+        .min(5, "Subject must be at least 5 characters")
+        .max(100, "Subject must be less than 100 characters"),
+    message: z
+        .string()
+        .min(10, "Message must be at least 10 characters")
+        .max(1000, "Message must be less than 1000 characters"),
+})
+
+type ContactFormValues = z.infer<typeof schema>
+
+export function ContactBlock({
+    payload,
+}: {
+    payload: Extract<SupportBlockPayload, { kind: "contact" }>
+}) {
+    const t = useTranslations("Contact")
+    const { user } = useAuth()
+    const [submitted, setSubmitted] = useState(false)
+
+    const form = useForm<ContactFormValues>({
+        resolver: zodResolver(schema),
+        defaultValues: {
+            name: user?.user_metadata?.full_name ?? "",
+            email: user?.email ?? "",
+            subject: "",
+            message: "",
+        },
+    })
+
+    const onSubmit = async (data: ContactFormValues) => {
+        try {
+            const response = await fetch("/api/contact", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(data),
+            })
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}))
+                throw new Error(
+                    err?.message || err?.error || `Request failed`,
+                )
+            }
+            toast.success(t("form.success"))
+            form.reset({
+                name: data.name,
+                email: data.email,
+                subject: "",
+                message: "",
+            })
+            setSubmitted(true)
+        } catch (err) {
+            const message =
+                err instanceof Error ? err.message : t("form.error")
+            toast.error(message)
+        }
+    }
+
+    const isSubmitting = form.formState.isSubmitting
+
+    return (
+        <div className='w-full md:max-w-[85%] overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-4 space-y-4'>
+            <div className='flex items-start justify-between gap-3'>
+                <div className='min-w-0'>
+                    <h4 className='text-sm font-semibold text-white'>
+                        {payload.title}
+                    </h4>
+                    <p className='mt-1 text-xs text-white/65'>
+                        {payload.description}
+                    </p>
+                </div>
+                <a
+                    href='mailto:admin@askingfate.com'
+                    className='shrink-0 inline-flex items-center gap-1.5 rounded-full border border-white/15 px-2.5 py-1 text-[11px] text-white/80 hover:text-white hover:border-white/30'
+                >
+                    <Mail className='h-3 w-3' />
+                    admin@askingfate.com
+                </a>
+            </div>
+
+            {submitted ? (
+                <div className='rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-sm text-emerald-100'>
+                    {t("form.success")}
+                </div>
+            ) : (
+                <Form {...form}>
+                    <form
+                        onSubmit={form.handleSubmit(onSubmit)}
+                        className='space-y-3'
+                    >
+                        <div className='grid grid-cols-1 sm:grid-cols-2 gap-3'>
+                            <FormField
+                                control={form.control}
+                                name='name'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel className='text-[11px] uppercase tracking-wider text-white/65'>
+                                            {t("form.name")} *
+                                        </FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                placeholder={t(
+                                                    "form.namePlaceholder",
+                                                )}
+                                                className='bg-background/30 border-border/30 text-foreground'
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name='email'
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel className='text-[11px] uppercase tracking-wider text-white/65'>
+                                            {t("form.email")} *
+                                        </FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                type='email'
+                                                placeholder={t(
+                                                    "form.emailPlaceholder",
+                                                )}
+                                                className='bg-background/30 border-border/30 text-foreground'
+                                                {...field}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                        <FormField
+                            control={form.control}
+                            name='subject'
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel className='text-[11px] uppercase tracking-wider text-white/65'>
+                                        {t("form.subject")} *
+                                    </FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            placeholder={t(
+                                                "form.subjectPlaceholder",
+                                            )}
+                                            className='bg-background/30 border-border/30 text-foreground'
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                        <FormField
+                            control={form.control}
+                            name='message'
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel className='text-[11px] uppercase tracking-wider text-white/65'>
+                                        {t("form.message")} *
+                                    </FormLabel>
+                                    <FormControl>
+                                        <Textarea
+                                            rows={4}
+                                            placeholder={t(
+                                                "form.messagePlaceholder",
+                                            )}
+                                            className='bg-background/30 border-border/30 text-foreground resize-none'
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                        <div className='flex flex-col gap-2 sm:flex-row sm:items-center'>
+                            <Button
+                                type='submit'
+                                disabled={isSubmitting}
+                                className='flex-1 bg-primary hover:bg-primary/90 text-primary-foreground'
+                            >
+                                <Send className='mr-2 h-4 w-4' />
+                                {isSubmitting
+                                    ? t("form.submitting")
+                                    : t("form.submit")}
+                            </Button>
+                            <Link
+                                href={payload.href}
+                                className='inline-flex items-center justify-center gap-1.5 rounded-md border border-white/15 px-4 py-2 text-sm text-white/85 hover:text-white hover:border-white/30'
+                            >
+                                {t("title")}
+                                <ArrowRight className='h-4 w-4' />
+                            </Link>
+                        </div>
+                    </form>
+                </Form>
+            )}
+        </div>
+    )
+}

--- a/components/chat/support/icon-map.tsx
+++ b/components/chat/support/icon-map.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import {
+    BookOpen,
+    Compass,
+    CreditCard,
+    HelpCircle,
+    Info,
+    LogIn,
+    Mail,
+    MessageCircleQuestion,
+    Moon,
+    Settings,
+    Share2,
+    Shield,
+    Sparkles,
+    Star,
+    User,
+    UserPlus,
+    Users,
+    Gamepad2,
+    type LucideIcon,
+} from "lucide-react"
+
+export const SUPPORT_ICON_MAP: Record<string, LucideIcon> = {
+    sparkles: Sparkles,
+    mail: Mail,
+    help: HelpCircle,
+    faq: MessageCircleQuestion,
+    book: BookOpen,
+    gamepad: Gamepad2,
+    share: Share2,
+    users: Users,
+    shield: Shield,
+    star: Star,
+    moon: Moon,
+    user: User,
+    settings: Settings,
+    info: Info,
+    "credit-card": CreditCard,
+    compass: Compass,
+    "log-in": LogIn,
+    "user-plus": UserPlus,
+}
+
+export function SupportIcon({
+    iconId,
+    className,
+}: {
+    iconId?: string | null
+    className?: string
+}) {
+    const Icon =
+        (iconId && SUPPORT_ICON_MAP[iconId]) || SUPPORT_ICON_MAP.sparkles
+    return <Icon className={className} />
+}

--- a/components/chat/support/page-block.tsx
+++ b/components/chat/support/page-block.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { Link } from "@/i18n/navigation"
+import { ArrowRight } from "lucide-react"
+import type { SupportBlockPayload } from "@/components/chat/types"
+import { SupportIcon } from "./icon-map"
+
+type Props = {
+    payload: Extract<SupportBlockPayload, { kind: "page" | "article" }>
+    ctaLabel?: string
+}
+
+export function PageBlock({ payload, ctaLabel = "Open page" }: Props) {
+    return (
+        <Link
+            href={payload.href}
+            className='group relative block w-full md:max-w-[85%] overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-4 transition-colors hover:border-primary/50 hover:bg-white/[0.06]'
+        >
+            <div className='flex items-start gap-3'>
+                <div className='flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/15 border border-primary/30 text-primary'>
+                    <SupportIcon iconId={payload.iconId} className='h-5 w-5' />
+                </div>
+                <div className='flex-1 min-w-0'>
+                    <h4 className='text-sm font-semibold text-white truncate'>
+                        {payload.title}
+                    </h4>
+                    <p className='mt-1 text-xs text-white/70 leading-relaxed line-clamp-3'>
+                        {payload.description}
+                    </p>
+                    <div className='mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-primary group-hover:text-primary/80'>
+                        {ctaLabel}
+                        <ArrowRight className='h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5' />
+                    </div>
+                </div>
+            </div>
+        </Link>
+    )
+}

--- a/components/chat/support/plan-block.tsx
+++ b/components/chat/support/plan-block.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import { useLocale, useTranslations } from "next-intl"
+import { ArrowRight, CheckCircle2, Crown, Star } from "lucide-react"
+import { Link } from "@/i18n/navigation"
+import type { SupportBlockPayload } from "@/components/chat/types"
+import {
+    SUBSCRIPTION_PLANS,
+    resolvePlanBillingPrice,
+} from "@/lib/payments/subscription-plans"
+import {
+    formatCurrency,
+    type CurrencyCode,
+} from "@/lib/payments/currency-utils"
+
+type Props = {
+    payload: Extract<SupportBlockPayload, { kind: "plan" }>
+}
+
+export function PlanBlock({ payload }: Props) {
+    const t = useTranslations("Pricing")
+    const locale = useLocale()
+    const currency: CurrencyCode = locale === "th" ? "THB" : "USD"
+
+    return (
+        <div className='w-full md:max-w-[85%] overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-4 space-y-4'>
+            <div className='flex items-center justify-between gap-3'>
+                <div className='min-w-0'>
+                    <h4 className='text-sm font-semibold text-white'>
+                        {payload.title}
+                    </h4>
+                    <p className='mt-1 text-xs text-white/65 line-clamp-2'>
+                        {payload.description}
+                    </p>
+                </div>
+                <span className='shrink-0 inline-flex items-center justify-center h-9 w-9 rounded-xl bg-indigo-500/15 border border-indigo-500/25'>
+                    <Crown className='h-4 w-4 text-indigo-300' />
+                </span>
+            </div>
+
+            <div className='grid gap-3 sm:grid-cols-2'>
+                {SUBSCRIPTION_PLANS.map((plan) => {
+                    const monthly = plan.billing?.monthly
+                    const annualNative = resolvePlanBillingPrice(
+                        plan,
+                        "annual",
+                        currency,
+                    )
+                    const monthlyPrice = resolvePlanBillingPrice(
+                        plan,
+                        "monthly",
+                        currency,
+                    )
+                    const annualMonthlyPrice =
+                        annualNative != null ? annualNative / 12 : undefined
+                    const discountPercent =
+                        monthlyPrice != null && annualMonthlyPrice != null
+                            ? Math.round(
+                                  (1 - annualMonthlyPrice / monthlyPrice) * 100,
+                              )
+                            : null
+
+                    return (
+                        <div
+                            key={plan.id}
+                            className='flex flex-col gap-2 rounded-xl border border-white/10 bg-black/30 p-3'
+                        >
+                            <div className='flex items-center justify-between gap-2'>
+                                <span className='text-sm font-semibold text-white'>
+                                    {t(plan.nameKey)}
+                                </span>
+                                {plan.badgeKey && (
+                                    <span className='inline-flex rounded-full bg-indigo-500/20 border border-indigo-500/30 px-2 py-[1px] text-[9px] font-bold tracking-widest uppercase text-indigo-200'>
+                                        {t(plan.badgeKey)}
+                                    </span>
+                                )}
+                            </div>
+                            <div className='flex items-baseline gap-1.5'>
+                                <Star className='h-3.5 w-3.5 fill-yellow-400 text-yellow-400 shrink-0' />
+                                <span className='text-lg font-bold text-white'>
+                                    {monthly?.stars}
+                                </span>
+                                <span className='text-[10px] uppercase tracking-widest text-white/60'>
+                                    {t("starsPerMonth")}
+                                </span>
+                            </div>
+                            <div className='flex items-baseline gap-1.5'>
+                                <span className='text-lg font-bold text-white'>
+                                    {monthlyPrice != null
+                                        ? formatCurrency(
+                                              monthlyPrice,
+                                              currency,
+                                              locale,
+                                          )
+                                        : "--"}
+                                </span>
+                                <span className='text-xs text-white/55'>
+                                    /{t("perMonth")}
+                                </span>
+                            </div>
+                            {discountPercent != null &&
+                            discountPercent > 0 ? (
+                                <div className='inline-flex w-fit rounded-full bg-emerald-500/15 border border-emerald-500/25 px-2 py-[1px] text-[10px] font-medium text-emerald-200'>
+                                    {t("savePercent", {
+                                        percent: discountPercent,
+                                    })}{" "}
+                                    {t("billedYearly")}
+                                </div>
+                            ) : null}
+                            <ul className='space-y-1 text-[11px] text-white/75'>
+                                <li className='flex items-center gap-1.5'>
+                                    <CheckCircle2 className='h-3 w-3 text-indigo-300 shrink-0' />
+                                    {t("bonusStars")}
+                                </li>
+                                <li className='flex items-center gap-1.5'>
+                                    <CheckCircle2 className='h-3 w-3 text-indigo-300 shrink-0' />
+                                    {t("cancelFromAccount")}
+                                </li>
+                            </ul>
+                        </div>
+                    )
+                })}
+            </div>
+
+            <Link
+                href={payload.href}
+                className='group inline-flex items-center justify-center gap-1.5 w-full rounded-xl bg-primary px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-primary/90'
+            >
+                {t("subscribeNow")}
+                <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-0.5' />
+            </Link>
+        </div>
+    )
+}

--- a/components/chat/support/star-packs-block.tsx
+++ b/components/chat/support/star-packs-block.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+import { ArrowRight, Star } from "lucide-react"
+import { Link } from "@/i18n/navigation"
+import type { SupportBlockPayload } from "@/components/chat/types"
+
+export function StarPacksBlock({
+    payload,
+}: {
+    payload: Extract<SupportBlockPayload, { kind: "star-packs" }>
+}) {
+    const t = useTranslations("Pricing")
+    const tStars = useTranslations("Stars")
+    return (
+        <div className='w-full md:max-w-[85%] overflow-hidden rounded-2xl border border-white/10 bg-white/[0.04] p-4 space-y-3'>
+            <div className='flex items-center gap-3'>
+                <span className='inline-flex h-10 w-10 items-center justify-center rounded-xl bg-yellow-400/15 border border-yellow-400/25 text-yellow-300'>
+                    <Star className='h-5 w-5 fill-current' />
+                </span>
+                <div className='min-w-0'>
+                    <h4 className='text-sm font-semibold text-white truncate'>
+                        {payload.title}
+                    </h4>
+                    <p className='mt-1 text-xs text-white/65 line-clamp-2'>
+                        {payload.description}
+                    </p>
+                </div>
+            </div>
+
+            <ul className='space-y-1.5 text-xs text-white/80'>
+                <li className='flex items-start gap-2'>
+                    <span className='mt-1.5 h-1 w-1 rounded-full bg-yellow-300 shrink-0' />
+                    {t("howFastStarsAnswer")}
+                </li>
+                <li className='flex items-start gap-2'>
+                    <span className='mt-1.5 h-1 w-1 rounded-full bg-yellow-300 shrink-0' />
+                    {t("pricingFaq.addonsAnswer")}
+                </li>
+            </ul>
+
+            <div className='flex flex-col gap-2 sm:flex-row sm:items-center'>
+                <Link
+                    href={payload.href}
+                    className='group inline-flex items-center justify-center gap-1.5 flex-1 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90'
+                >
+                    {tStars("addStars")}
+                    <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-0.5' />
+                </Link>
+                <Link
+                    href='/pricing'
+                    className='group inline-flex items-center justify-center gap-1.5 rounded-xl border border-white/15 px-4 py-2 text-sm font-medium text-white/85 hover:text-white hover:border-white/30'
+                >
+                    {t("subscriptionPlans")}
+                </Link>
+            </div>
+        </div>
+    )
+}

--- a/components/chat/support/support-block.tsx
+++ b/components/chat/support/support-block.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import type { SupportBlockPayload } from "@/components/chat/types"
+import { PlanBlock } from "./plan-block"
+import { StarPacksBlock } from "./star-packs-block"
+import { ContactBlock } from "./contact-block"
+import { TarotCardBlock } from "./tarot-card-block"
+import { ArticleBlock } from "./article-block"
+import { PageBlock } from "./page-block"
+
+export function SupportBlock({ payload }: { payload: SupportBlockPayload }) {
+    if (payload.kind === "plan") {
+        return <PlanBlock payload={payload} />
+    }
+    if (payload.kind === "star-packs") {
+        return <StarPacksBlock payload={payload} />
+    }
+    if (payload.kind === "contact") {
+        return <ContactBlock payload={payload} />
+    }
+    if (payload.kind === "tarot-card") {
+        return <TarotCardBlock payload={payload} />
+    }
+    if (payload.kind === "article") {
+        return <ArticleBlock payload={payload} />
+    }
+    return <PageBlock payload={payload} />
+}

--- a/components/chat/support/tarot-card-block.tsx
+++ b/components/chat/support/tarot-card-block.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import Image from "next/image"
+import { ArrowRight, RotateCcw } from "lucide-react"
+import { useTranslations } from "next-intl"
+import { Link } from "@/i18n/navigation"
+import type { SupportBlockPayload } from "@/components/chat/types"
+
+type Props = {
+    payload: Extract<SupportBlockPayload, { kind: "tarot-card" }>
+}
+
+export function TarotCardBlock({ payload }: Props) {
+    const t = useTranslations("TarotArticle")
+
+    return (
+        <div className='w-full md:max-w-[85%] overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-indigo-500/10 via-purple-500/5 to-fuchsia-500/10 p-4'>
+            <div className='flex items-start gap-4'>
+                <div className='relative h-32 w-20 shrink-0 overflow-hidden rounded-xl border border-white/15 bg-black/40 sm:h-44 sm:w-28'>
+                    <Image
+                        src={`/assets/rider-waite-tarot/${payload.cardSlug}.png`}
+                        alt={payload.cardName}
+                        fill
+                        sizes='(min-width: 640px) 112px, 80px'
+                        className='object-contain drop-shadow-xl'
+                    />
+                </div>
+                <div className='flex-1 min-w-0 space-y-2'>
+                    <div className='flex items-center justify-between gap-2'>
+                        <h4 className='text-base font-serif font-semibold text-white truncate'>
+                            {payload.cardName}
+                        </h4>
+                        <span className='shrink-0 inline-flex rounded-full bg-white/10 border border-white/15 px-2 py-[1px] text-[10px] uppercase tracking-widest text-white/75'>
+                            {payload.arcana === "major"
+                                ? "Major Arcana"
+                                : `Minor · ${payload.suit ?? ""}`}
+                        </span>
+                    </div>
+                    <p className='text-xs text-white/70 leading-relaxed line-clamp-3'>
+                        {payload.description}
+                    </p>
+
+                    <div className='space-y-1.5'>
+                        <div className='flex items-start gap-2'>
+                            <span className='shrink-0 mt-[2px] text-[10px] font-bold uppercase tracking-wider text-emerald-300/90'>
+                                {t("upright")}
+                            </span>
+                            <div className='flex flex-wrap gap-1'>
+                                {payload.uprightKeywords
+                                    .slice(0, 4)
+                                    .map((kw) => (
+                                        <span
+                                            key={kw}
+                                            className='inline-flex rounded-full bg-emerald-500/10 border border-emerald-500/25 px-2 py-[1px] text-[10px] text-emerald-100'
+                                        >
+                                            {kw}
+                                        </span>
+                                    ))}
+                            </div>
+                        </div>
+                        <div className='flex items-start gap-2'>
+                            <span className='shrink-0 mt-[2px] text-[10px] font-bold uppercase tracking-wider text-amber-300/90 inline-flex items-center gap-1'>
+                                <RotateCcw className='h-2.5 w-2.5' />
+                                {t("reversed")}
+                            </span>
+                            <div className='flex flex-wrap gap-1'>
+                                {payload.reversedKeywords
+                                    .slice(0, 4)
+                                    .map((kw) => (
+                                        <span
+                                            key={kw}
+                                            className='inline-flex rounded-full bg-amber-500/10 border border-amber-500/25 px-2 py-[1px] text-[10px] text-amber-100'
+                                        >
+                                            {kw}
+                                        </span>
+                                    ))}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <Link
+                href={payload.href}
+                className='group mt-4 inline-flex items-center justify-center gap-1.5 w-full rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90'
+            >
+                Read full meaning
+                <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-0.5' />
+            </Link>
+        </div>
+    )
+}

--- a/components/chat/types.ts
+++ b/components/chat/types.ts
@@ -9,6 +9,10 @@ import type { PromptRedactionType } from "@/lib/privacy/prompt-redaction"
 import type { ConversationContextPayload } from "@/lib/astrology/question-context"
 import type { PersonalizedTransitAspectsResult } from "@/lib/astrology/transit-aspects"
 import type { QuestionDomain } from "@/lib/chat/situation-schema"
+import type {
+    SupportBlockKind,
+    SupportTopic,
+} from "@/lib/chat/support-topics"
 
 export type AspectInsightItem = {
     aspectKey: string
@@ -144,17 +148,84 @@ export type ChatMessage = {
     >
     /** True when a stream was manually stopped and partial text should be preserved */
     streamStopped?: boolean
+    /** Topic resolved for support-mode replies, used by SupportBlock rendering. */
+    supportTopic?: SupportTopic
+    /** Concrete data the support tool block needs to render. */
+    supportBlock?: SupportBlockPayload | null
 }
 
 export type ChatDecision = {
-    type: "chat" | "draw" | "horoscope"
+    type: "chat" | "draw" | "horoscope" | "support"
     spreadType?: string
     cardCount?: number
     spreadReason?: string
     assistantText?: string
     /** True if the user's message is directly related to the last message (follow-up) */
     isFollowUp?: boolean
+    /** When type === "support": which tool block to render. */
+    supportTopic?: SupportTopic
+    /** When supportTopic === "tarot-card": canonical card slug. */
+    supportCardSlug?: string
 }
+
+/**
+ * Concrete payload consumed by the SupportBlock renderer in the chat. The
+ * decision route returns a `supportTopic`; the chat session resolves it into
+ * one of these payload shapes before persisting on the assistant message.
+ */
+export type SupportBlockPayload =
+    | {
+          kind: "plan"
+          topic: SupportTopic
+          href: string
+          title: string
+          description: string
+      }
+    | {
+          kind: "star-packs"
+          topic: SupportTopic
+          href: string
+          title: string
+          description: string
+      }
+    | {
+          kind: "contact"
+          topic: SupportTopic
+          href: string
+          title: string
+          description: string
+      }
+    | {
+          kind: "tarot-card"
+          topic: SupportTopic
+          href: string
+          title: string
+          description: string
+          cardSlug: string
+          cardName: string
+          arcana: "major" | "minor"
+          suit: "wands" | "cups" | "swords" | "pentacles" | null
+          uprightKeywords: string[]
+          reversedKeywords: string[]
+      }
+    | {
+          kind: "article"
+          topic: SupportTopic
+          href: string
+          title: string
+          description: string
+          iconId?: string
+      }
+    | {
+          kind: "page"
+          topic: SupportTopic
+          href: string
+          title: string
+          description: string
+          iconId?: string
+      }
+
+export type SupportBlockPayloadKind = SupportBlockKind
 
 export type HoroscopeExtractResponse = {
     birthDate?: {

--- a/lib/chat/decision-schema.ts
+++ b/lib/chat/decision-schema.ts
@@ -10,11 +10,38 @@ export const tarotSpreadSchema = z.enum([
 
 export type TarotSpreadType = z.infer<typeof tarotSpreadSchema>
 
+export const supportTopicSchema = z.enum([
+    "pricing",
+    "star-packs",
+    "contact",
+    "help",
+    "faq",
+    "how-to-play",
+    "privacy-redaction",
+    "privacy-policy",
+    "terms-of-service",
+    "refer-a-friend",
+    "share-reading",
+    "create-content",
+    "tarot-card",
+    "tarot-cards-index",
+    "birth-chart",
+    "horoscope",
+    "account",
+    "settings",
+    "about",
+    "articles",
+    "sign-in",
+    "sign-up",
+])
+
+export type SupportTopicSchema = z.infer<typeof supportTopicSchema>
+
 export const chatDecisionSchema = z.object({
     type: z
-        .enum(["chat", "draw", "horoscope"])
+        .enum(["chat", "draw", "horoscope", "support"])
         .describe(
-            "Classification: chat (knowledge), draw (tarot), horoscope (astrology/timing)",
+            "Classification: chat (knowledge), draw (tarot), horoscope (astrology/timing), support (website/product info -> inline tool block)",
         ),
     isFollowUp: z
         .boolean()
@@ -32,6 +59,17 @@ export const chatDecisionSchema = z.object({
         .optional()
         .describe(
             "Only for draw. One short sentence explaining why the chosen spread fits the user's question.",
+        ),
+    supportTopic: supportTopicSchema
+        .optional()
+        .describe(
+            "Only for support. Which product topic the inline tool block should render. Required when type === 'support'.",
+        ),
+    supportCardSlug: z
+        .string()
+        .optional()
+        .describe(
+            "Only for support + tarot-card. Canonical kebab-case card slug, e.g. 'seven-of-cups', 'the-fool'. If unsure, omit it; the client will try to detect from the user message.",
         ),
 })
 

--- a/lib/chat/support-block.ts
+++ b/lib/chat/support-block.ts
@@ -1,0 +1,118 @@
+/**
+ * Build a concrete SupportBlockPayload from a chat decision + the user
+ * question. Resolves tarot cards from the user message when the model did not
+ * provide a slug, and falls back to a generic page block otherwise.
+ */
+
+import type { ChatDecision, SupportBlockPayload } from "@/components/chat/types"
+import { TAROT_CARDS } from "@/lib/tarot/cards"
+import {
+    getSupportTopicMeta,
+    matchSupportTopicLocally,
+    matchTarotCardSlug,
+    type SupportTopic,
+    type SupportTopicMeta,
+} from "./support-topics"
+
+function findCardBySlug(slug: string | undefined | null) {
+    if (!slug) return null
+    const normalized = slug.toLowerCase().trim()
+    return (
+        TAROT_CARDS.find((c) => c.slug === normalized) ??
+        TAROT_CARDS.find((c) => c.name.toLowerCase() === normalized) ??
+        null
+    )
+}
+
+function buildBlockFromMeta(
+    meta: SupportTopicMeta,
+    options: { question: string; supportCardSlug?: string | null } = {
+        question: "",
+    },
+): SupportBlockPayload {
+    const base = {
+        topic: meta.topic,
+        href: meta.href,
+        title: meta.title,
+        description: meta.description,
+    }
+
+    if (meta.block === "tarot-card") {
+        const slug =
+            findCardBySlug(options.supportCardSlug ?? undefined)?.slug ??
+            matchTarotCardSlug(options.question ?? "")
+        const card = findCardBySlug(slug)
+        if (!card) {
+            return {
+                kind: "page",
+                ...base,
+                href: "/articles/tarot",
+                title: "Tarot card meanings",
+                description:
+                    "Browse all 78 cards — Major Arcana and the four Minor Arcana suits.",
+                iconId: meta.iconId,
+            }
+        }
+        return {
+            kind: "tarot-card",
+            ...base,
+            href: `/articles/tarot/${card.slug}`,
+            title: card.name,
+            description: card.description,
+            cardSlug: card.slug,
+            cardName: card.name,
+            arcana: card.arcana,
+            suit: card.suit,
+            uprightKeywords: card.uprightKeywords,
+            reversedKeywords: card.reversedKeywords,
+        }
+    }
+
+    if (meta.block === "plan") {
+        return { kind: "plan", ...base }
+    }
+    if (meta.block === "star-packs") {
+        return { kind: "star-packs", ...base }
+    }
+    if (meta.block === "contact") {
+        return { kind: "contact", ...base }
+    }
+    if (meta.block === "article") {
+        return {
+            kind: "article",
+            ...base,
+            iconId: meta.iconId,
+        }
+    }
+    return {
+        kind: "page",
+        ...base,
+        iconId: meta.iconId,
+    }
+}
+
+export function buildSupportBlockFromDecision(
+    decision: ChatDecision,
+    question: string,
+): SupportBlockPayload | null {
+    if (decision.type !== "support") return null
+    const topic = resolveTopicFromDecision(decision, question)
+    if (!topic) return null
+    const meta = getSupportTopicMeta(topic)
+    if (!meta) return null
+    return buildBlockFromMeta(meta, {
+        question,
+        supportCardSlug: decision.supportCardSlug,
+    })
+}
+
+export function resolveTopicFromDecision(
+    decision: ChatDecision,
+    question: string,
+): SupportTopic | null {
+    if (decision.supportTopic) {
+        const meta = getSupportTopicMeta(decision.supportTopic)
+        if (meta) return meta.topic
+    }
+    return matchSupportTopicLocally(question)
+}

--- a/lib/chat/support-topics.ts
+++ b/lib/chat/support-topics.ts
@@ -1,0 +1,474 @@
+/**
+ * Support topics surfaced by the chat decision engine.
+ *
+ * Whenever the user asks about a part of the AskingFate product (pricing,
+ * contact, articles, tarot cards, account, etc.) the classifier emits a
+ * `support` decision pointing at one of these topics. The client then resolves
+ * the topic into a rich, in-session UI block ("tool block") that embeds a
+ * snapshot of the destination page plus a CTA link to the full page.
+ *
+ * Adding a new topic only needs an entry in the `SUPPORT_TOPICS` map plus the
+ * matching renderer in `components/chat/support`.
+ */
+
+import { TAROT_CARDS } from "@/lib/tarot/cards"
+
+/** Identifier for a support topic the AI can pick. */
+export type SupportTopic =
+    | "pricing"
+    | "star-packs"
+    | "contact"
+    | "help"
+    | "faq"
+    | "how-to-play"
+    | "privacy-redaction"
+    | "privacy-policy"
+    | "terms-of-service"
+    | "refer-a-friend"
+    | "share-reading"
+    | "create-content"
+    | "tarot-card"
+    | "tarot-cards-index"
+    | "birth-chart"
+    | "horoscope"
+    | "account"
+    | "settings"
+    | "about"
+    | "articles"
+    | "sign-in"
+    | "sign-up"
+
+/** Tool block variants rendered inline in the chat for support answers. */
+export type SupportBlockKind =
+    | "plan"
+    | "star-packs"
+    | "contact"
+    | "tarot-card"
+    | "article"
+    | "page"
+
+export type SupportTopicMeta = {
+    topic: SupportTopic
+    /** Localized destination path (already prefixed by `/`; locale routing applied at render). */
+    href: string
+    /** Default headline used as a fallback when no translation is available. */
+    title: string
+    /** Default description used as a fallback when no translation is available. */
+    description: string
+    /** Block renderer to pick. Defaults to `"page"`. */
+    block: SupportBlockKind
+    /** Lucide icon name used by the page-block renderer when no richer block applies. */
+    iconId?:
+        | "sparkles"
+        | "mail"
+        | "help"
+        | "faq"
+        | "book"
+        | "gamepad"
+        | "share"
+        | "users"
+        | "shield"
+        | "star"
+        | "moon"
+        | "user"
+        | "settings"
+        | "info"
+        | "credit-card"
+        | "compass"
+        | "log-in"
+        | "user-plus"
+    /** Keywords used by the lightweight local fallback intent matcher. */
+    keywords: readonly string[]
+}
+
+export const SUPPORT_TOPICS: Record<SupportTopic, SupportTopicMeta> = {
+    pricing: {
+        topic: "pricing",
+        href: "/pricing",
+        title: "Pricing plans",
+        description:
+            "Pick a Basic or Pro subscription, see monthly vs annual stars, and continue to checkout.",
+        block: "plan",
+        iconId: "credit-card",
+        keywords: [
+            "price",
+            "pricing",
+            "plan",
+            "plans",
+            "subscription",
+            "subscribe",
+            "cost",
+            "tier",
+            "premium",
+            "upgrade",
+            "billing",
+            "monthly",
+            "annual",
+            "yearly",
+        ],
+    },
+    "star-packs": {
+        topic: "star-packs",
+        href: "/stars",
+        title: "Stars & add-on packs",
+        description:
+            "See your star balance, refill rules, and one-time add-on packs for Pro subscribers.",
+        block: "star-packs",
+        iconId: "star",
+        keywords: [
+            "stars",
+            "star",
+            "pack",
+            "packs",
+            "balance",
+            "refill",
+            "top up",
+            "topup",
+            "buy stars",
+            "add-on",
+            "addon",
+        ],
+    },
+    contact: {
+        topic: "contact",
+        href: "/contact",
+        title: "Contact support",
+        description:
+            "Send us a message. We typically reply within 1 business day at admin@askingfate.com.",
+        block: "contact",
+        iconId: "mail",
+        keywords: [
+            "contact",
+            "support",
+            "help me",
+            "talk to human",
+            "human",
+            "email",
+            "reach out",
+            "report bug",
+            "issue",
+            "problem",
+            "complaint",
+        ],
+    },
+    help: {
+        topic: "help",
+        href: "/articles/help-support",
+        title: "Help & support",
+        description:
+            "Common troubleshooting for accounts, readings, billing, and stars.",
+        block: "article",
+        iconId: "help",
+        keywords: [
+            "help",
+            "support article",
+            "troubleshoot",
+            "fix",
+            "broken",
+            "not working",
+        ],
+    },
+    faq: {
+        topic: "faq",
+        href: "/articles/faq",
+        title: "Frequently asked questions",
+        description:
+            "Quick answers about readings, stars, accuracy, and billing.",
+        block: "article",
+        iconId: "faq",
+        keywords: ["faq", "questions", "common", "answers"],
+    },
+    "how-to-play": {
+        topic: "how-to-play",
+        href: "/articles/how-to-play",
+        title: "How to play",
+        description:
+            "Ask a question, pick cards, and reflect on the meaning — step by step.",
+        block: "article",
+        iconId: "gamepad",
+        keywords: [
+            "how to use",
+            "how do i play",
+            "how to play",
+            "how does it work",
+            "how it works",
+            "guide",
+            "tutorial",
+            "beginner",
+            "getting started",
+        ],
+    },
+    "privacy-redaction": {
+        topic: "privacy-redaction",
+        href: "/articles/privacy-redaction",
+        title: "Privacy & PII redaction",
+        description:
+            "How AskingFate detects and removes personal details from your prompts.",
+        block: "article",
+        iconId: "shield",
+        keywords: [
+            "privacy",
+            "pii",
+            "redaction",
+            "personal information",
+            "redact",
+            "anonymous",
+            "anonymise",
+        ],
+    },
+    "privacy-policy": {
+        topic: "privacy-policy",
+        href: "/privacy-policy",
+        title: "Privacy policy",
+        description: "How we collect, use, and protect your data.",
+        block: "page",
+        iconId: "shield",
+        keywords: ["privacy policy", "data", "data protection", "gdpr"],
+    },
+    "terms-of-service": {
+        topic: "terms-of-service",
+        href: "/terms-of-service",
+        title: "Terms of service",
+        description: "Our terms, acceptable use, and payment policy.",
+        block: "page",
+        iconId: "info",
+        keywords: ["terms", "tos", "rules", "policy"],
+    },
+    "refer-a-friend": {
+        topic: "refer-a-friend",
+        href: "/articles/refer-a-friend",
+        title: "Refer a friend",
+        description:
+            "Invite friends to AskingFate. You both earn stars when they join.",
+        block: "article",
+        iconId: "users",
+        keywords: [
+            "refer",
+            "referral",
+            "invite friend",
+            "invite a friend",
+            "invite people",
+        ],
+    },
+    "share-reading": {
+        topic: "share-reading",
+        href: "/articles/share-reading",
+        title: "Share a reading",
+        description:
+            "Share your reading link and earn up to 3 stars per day from visits.",
+        block: "article",
+        iconId: "share",
+        keywords: ["share", "share reading", "share link"],
+    },
+    "create-content": {
+        topic: "create-content",
+        href: "/articles/create-content",
+        title: "Create content & earn stars",
+        description:
+            "Write, post, or film about AskingFate and earn stars when your content is approved.",
+        block: "article",
+        iconId: "book",
+        keywords: [
+            "create content",
+            "make content",
+            "earn stars",
+            "creator",
+            "blog",
+            "video",
+            "post about",
+        ],
+    },
+    "tarot-card": {
+        topic: "tarot-card",
+        href: "/articles/tarot",
+        title: "Tarot card",
+        description:
+            "Upright and reversed meanings with practical guidance.",
+        block: "tarot-card",
+        iconId: "moon",
+        keywords: [
+            "card mean",
+            "card means",
+            "what does",
+            "tarot card",
+            "meaning of",
+        ],
+    },
+    "tarot-cards-index": {
+        topic: "tarot-cards-index",
+        href: "/articles/tarot",
+        title: "All tarot cards",
+        description:
+            "Browse all 78 cards — Major Arcana and the four Minor Arcana suits.",
+        block: "article",
+        iconId: "book",
+        keywords: [
+            "all tarot cards",
+            "list of cards",
+            "every card",
+            "tarot deck",
+            "the deck",
+        ],
+    },
+    "birth-chart": {
+        topic: "birth-chart",
+        href: "/birth-chart",
+        title: "Birth chart",
+        description:
+            "See your personalized Swiss Ephemeris birth chart, planets, and houses.",
+        block: "page",
+        iconId: "compass",
+        keywords: [
+            "birth chart",
+            "natal chart",
+            "natal",
+            "astrology chart",
+            "houses",
+            "planets",
+        ],
+    },
+    horoscope: {
+        topic: "horoscope",
+        href: "/articles/how-to-play",
+        title: "Personalized horoscope",
+        description:
+            "Daily, monthly, and yearly horoscope readings based on your birth and today’s sky.",
+        block: "page",
+        iconId: "moon",
+        keywords: [
+            "horoscope feature",
+            "horoscope page",
+            "astrology reading",
+            "sky",
+            "transit",
+        ],
+    },
+    account: {
+        topic: "account",
+        href: "/account",
+        title: "Account",
+        description: "Manage your profile, subscription, and saved birth info.",
+        block: "page",
+        iconId: "user",
+        keywords: [
+            "account",
+            "my profile",
+            "manage account",
+            "delete account",
+            "logout",
+            "sign out",
+        ],
+    },
+    settings: {
+        topic: "settings",
+        href: "/settings",
+        title: "Settings",
+        description:
+            "Adjust appearance, locale, notifications, and reading preferences.",
+        block: "page",
+        iconId: "settings",
+        keywords: ["settings", "preferences", "options"],
+    },
+    about: {
+        topic: "about",
+        href: "/about",
+        title: "About AskingFate",
+        description:
+            "Our mission, how we built the product, and what makes our readings different.",
+        block: "page",
+        iconId: "info",
+        keywords: ["about", "who are you", "what is askingfate", "team"],
+    },
+    articles: {
+        topic: "articles",
+        href: "/articles",
+        title: "Articles & guides",
+        description:
+            "Documentation-style guides covering everything in AskingFate.",
+        block: "page",
+        iconId: "book",
+        keywords: ["articles", "guides", "blog", "docs", "documentation"],
+    },
+    "sign-in": {
+        topic: "sign-in",
+        href: "/signin",
+        title: "Sign in",
+        description: "Sign in to save your readings, stars, and birth profile.",
+        block: "page",
+        iconId: "log-in",
+        keywords: ["sign in", "log in", "login", "signin"],
+    },
+    "sign-up": {
+        topic: "sign-up",
+        href: "/signup",
+        title: "Create an account",
+        description:
+            "Make a free account to keep your readings, stars, and birth profile.",
+        block: "page",
+        iconId: "user-plus",
+        keywords: ["sign up", "signup", "register", "create account"],
+    },
+}
+
+export const SUPPORT_TOPIC_LIST = Object.values(SUPPORT_TOPICS)
+
+export function getSupportTopicMeta(
+    topic: SupportTopic | string | null | undefined,
+): SupportTopicMeta | null {
+    if (!topic) return null
+    if (topic in SUPPORT_TOPICS) {
+        return SUPPORT_TOPICS[topic as SupportTopic]
+    }
+    return null
+}
+
+/**
+ * Lightweight local fallback intent matcher. Used only when the LLM did not
+ * supply a topic explicitly. Picks the first topic with keyword overlap.
+ */
+export function matchSupportTopicLocally(
+    text: string,
+): SupportTopic | null {
+    const lower = (text ?? "").toLowerCase()
+    if (!lower.trim()) return null
+
+    // Tarot card mentions trump generic keywords.
+    const card = matchTarotCardSlug(lower)
+    if (card) return "tarot-card"
+
+    for (const meta of SUPPORT_TOPIC_LIST) {
+        for (const keyword of meta.keywords) {
+            if (lower.includes(keyword)) {
+                return meta.topic
+            }
+        }
+    }
+    return null
+}
+
+/**
+ * Try to recognise a tarot card name inside free text. Returns the canonical
+ * card slug. Handles "the seven of cups", "seven of cups", "the fool", etc.
+ */
+export function matchTarotCardSlug(text: string): string | null {
+    const lower = ` ${(text ?? "").toLowerCase()} `
+    let best: { slug: string; score: number } | null = null
+    for (const card of TAROT_CARDS) {
+        const name = card.name.toLowerCase()
+        const without = name.replace(/^the\s+/, "")
+        const candidates = new Set<string>([
+            name,
+            without,
+            name.replace(/\s+/g, " "),
+        ])
+        for (const candidate of candidates) {
+            if (lower.includes(` ${candidate} `)) {
+                const score = candidate.length
+                if (!best || score > best.score) {
+                    best = { slug: card.slug, score }
+                }
+            }
+        }
+    }
+    return best ? best.slug : null
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refines the Astra chat/support mode so the AI can answer product questions about AskingFate with **structured tool calls** that render a rich, in-session UI block plus a CTA button to the full page.

Additionally, the "chat" entry in the interpretation-mode selector is now the **merged chat+support mode** — selecting it gives the same auto-style routing but restricted to chat-or-support (never draw/horoscope). The user-facing list of modes stays at `auto / chat / tarot / horoscope`; there is no separate "support" pill.

## Decision types

```
chat | draw | horoscope | support
```

The model picks `support` whenever the message is about the AskingFate website / product itself. Topic enum (in `lib/chat/decision-schema.ts` + `lib/chat/support-topics.ts`):

```
pricing            -> /pricing                       (plan-block)
star-packs         -> /stars                         (star-packs)
contact            -> /contact                       (contact-block)
help               -> /articles/help-support         (article)
faq                -> /articles/faq                  (article)
how-to-play        -> /articles/how-to-play          (article)
privacy-redaction  -> /articles/privacy-redaction    (article)
privacy-policy     -> /privacy-policy                (page)
terms-of-service   -> /terms-of-service              (page)
refer-a-friend     -> /articles/refer-a-friend       (article)
share-reading      -> /articles/share-reading        (article)
create-content     -> /articles/create-content       (article)
tarot-card         -> /articles/tarot/{slug}         (tarot-card hero)
tarot-cards-index  -> /articles/tarot                (article)
birth-chart        -> /birth-chart                   (page)
horoscope (info)   -> /articles/how-to-play          (page)
account            -> /account                       (page)
settings           -> /settings                      (page)
about              -> /about                         (page)
articles           -> /articles                      (page)
sign-in            -> /signin                        (page)
sign-up            -> /signup                        (page)
```

For `tarot-card`, the classifier returns `supportCardSlug` (canonical `kebab-case` slug e.g. `seven-of-cups`, `the-fool`). The client also has a local fallback matcher (`matchTarotCardSlug`) that scans the message in case the model omits the slug.

## Interpretation-mode routing

```
auto       -> AI picks chat | draw | horoscope | support
chat       -> AI picks chat | support           (merged mode)
tarot      -> AI picks draw (with spread)       (+ support overrides)
horoscope  -> AI picks horoscope                (+ support overrides)
```

- `MODE_TO_TYPE.chat` in the decision route is now `["chat", "support"]`. When the user has locked chat mode, the system prompt instructs the model to pick exactly one of those two and never `draw`/`horoscope`.
- `applyInterpretationModeOverride` on the client mirrors that contract: in chat mode it keeps `chat` and `support` decisions, downgrades anything else (e.g. stale model output) to `chat`.
- Support decisions still bypass tarot/horoscope mode locks so product questions keep working even when the user has hard-locked a reading mode.

## What the user sees

`POST /api/chat/respond` is also taught about `support` mode: it returns a 1–2 sentence oracle acknowledgement (no markdown, no URLs) so the heavy detail can live inside the inline block.

Below the streamed text, the assistant message renders one of:

- **PlanBlock** – Basic + Pro tiers, current locale currency, monthly price, annual savings badge, "Subscribe now" CTA → `/pricing`.
- **StarPacksBlock** – refill + add-on rules, "Add stars" + "Subscription plans" CTAs.
- **ContactBlock** – compact contact form using the same `/api/contact` endpoint with name/email/subject/message + email shortcut + "Contact" CTA.
- **TarotCardBlock** – card hero with Rider-Waite image, arcana / suit badge, upright + reversed keyword chips, "Read full meaning" CTA.
- **ArticleBlock / PageBlock** – icon, title, description, "Read article" or "Open page" CTA.

All blocks live under `components/chat/support/` and share an icon map.

## Persistence

`supportTopic` and `supportBlock` are plain fields on `ChatMessage`. The existing `sanitizeMessagesForPersistence` preserves them, so reloading a chat session restores the inline block.

## Test plan

- `npx tsc --noEmit` — clean (only pre-existing errors in test files using `.ts` import extensions).
- `npx eslint` on touched files — clean.
- `npx next build` — compile + TypeScript pass succeeds; build error after that point is unrelated and only fails when collecting page data without Supabase/Stripe env vars.

## Follow-ups (intentionally out of scope)

- The classifier prompt is in English only; we should add a translated description of each topic when we get serious about localised intent. Today the model still handles non-English questions because the topic keys themselves are language-agnostic.
- The contact form duplicates the schema in `app/[locale]/contact/page.tsx`; if we add more entry points we should factor it into a shared component.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20453cc3-c7d5-4421-874a-37731a3372fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20453cc3-c7d5-4421-874a-37731a3372fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

