### PR TITLE
fix(home): show quick feature cards alongside cookie banner

### DIFF
--- a/components/home/index.tsx
+++ b/components/home/index.tsx
@@ -42,7 +42,7 @@ export default function Home() {
     const locale = useLocale()
     const router = useRouter()
     const { user } = useAuth()
-    const { cookieConsent, ageGateState } = useStarConsent()
+    const { ageGateState } = useStarConsent()
     const [question, setQuestion] = useState("")
     const [isLinking, setIsLinking] = useState(false)
     const [linkingQuestion, setLinkingQuestion] = useState<string | null>(null)
@@ -305,9 +305,6 @@ export default function Home() {
 
     const shouldShowHero = !isLinking
     const shouldShowLearnMore = showLearnMore && !isLinking
-    const cookieBannerVisible = !cookieConsent.decisionMade
-    const showQuickCards = !cookieBannerVisible
-
     const randomQuestionPool = useMemo(() => {
         const prompts = tHome.raw("prompts")
         const arr = Array.isArray(prompts)
@@ -455,7 +452,7 @@ export default function Home() {
                         onScrollToDraw: () => {},
                     }}
                     actionTrigger={
-                        showQuickCards && !isLinking ? (
+                        !isLinking ? (
                             <div className='w-full space-y-2 text-left'>
                                 <p className='text-left text-[11px] font-semibold uppercase tracking-[0.18em] text-white/70'>
                                     {tHome("quickFeaturesLabel")}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the home page, the composer’s quick feature cards (`HomeQuickCards` in `actionTrigger`) were hidden whenever the cookie consent banner was visible (`showQuickCards` was tied to `!cookieBannerVisible`). That made the action row disappear as soon as the inline cookie UI appeared.

## Change

- Stop coupling quick cards to cookie consent state.
- Render the quick feature row whenever the user is not in the “linking session” loading state (`!isLinking`), so quick cards stay visible next to the inline `CookiesBanner`.

## Notes

- Removed the unused `cookieConsent` destructure from `useStarConsent()` on this page (only `ageGateState` is still needed for birth data).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ae15b4d-caf7-40ef-ae81-a291f3f0ca39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ae15b4d-caf7-40ef-ae81-a291f3f0ca39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

