### PR TITLE
Handle daily shorthand date ranges

### DIFF
--- a/lib/astrology/__tests__/question-time-range.test.ts
+++ b/lib/astrology/__tests__/question-time-range.test.ts
@@ -93,6 +93,28 @@ test("Thai 'this month' timing question ends on last day of current month", () =
     assert.equal(range.granularity, "daily")
 })
 
+test("day-of-month range with daily phrasing resolves to explicit daily window", () => {
+    const range = resolveQuestionTimeRange(
+        "What will happen to me on 19-23 in daily",
+        { now: new Date("2026-05-10T00:00:00.000Z") },
+    )
+    assert.equal(range.source, "explicit")
+    assert.equal(range.startDateIso, "2026-05-19")
+    assert.equal(range.endDateIso, "2026-05-23")
+    assert.equal(range.granularity, "daily")
+})
+
+test("Thai day-of-month range resolves to explicit daily window", () => {
+    const range = resolveQuestionTimeRange(
+        "จะเกิดอะไรขึ้นกับกูในวันที่ 19-23 รายวัน",
+        { now: new Date("2026-05-10T00:00:00.000Z") },
+    )
+    assert.equal(range.source, "explicit")
+    assert.equal(range.startDateIso, "2026-05-19")
+    assert.equal(range.endDateIso, "2026-05-23")
+    assert.equal(range.granularity, "daily")
+})
+
 test("async: returns default_30d when regex has no match and AI returns 30", async () => {
     const range = await resolveQuestionTimeRangeAsync("Tell me about my love life", {
         now: new Date("2026-03-01T00:00:00.000Z"),

--- a/lib/astrology/__tests__/single-day.test.ts
+++ b/lib/astrology/__tests__/single-day.test.ts
@@ -145,6 +145,17 @@ test("looksLikeNatalQuestion: explicit dates → false", () => {
     assert.equal(looksLikeNatalQuestion("June 12, 2026?"), false)
 })
 
+test("looksLikeNatalQuestion: day-of-month ranges → false", () => {
+    assert.equal(
+        looksLikeNatalQuestion("What will happen to me on 19-23 in daily"),
+        false,
+    )
+    assert.equal(
+        looksLikeNatalQuestion("จะเกิดอะไรขึ้นกับกูในวันที่ 19-23 รายวัน"),
+        false,
+    )
+})
+
 test("looksLikeNatalQuestion: empty / non-string input is safe", () => {
     assert.equal(looksLikeNatalQuestion(""), false)
     assert.equal(looksLikeNatalQuestion(undefined as unknown as string), false)

--- a/lib/astrology/question-time-range.ts
+++ b/lib/astrology/question-time-range.ts
@@ -2,6 +2,8 @@ import { resolveTimeRangeDaysWithAI } from "./ai-time-range"
 
 const DEFAULT_FALLBACK_DAYS = 30
 const DAY_MS = 24 * 60 * 60 * 1000
+const DAILY_DISTRIBUTION_RE =
+    /รายวัน|วันต่อวัน|\b(daily|day by day|each day|per day)\b|ແບບລາຍວັນ/i
 
 export type TimeRangeSource =
     | "explicit"
@@ -124,6 +126,72 @@ function toValidUtcDate(year: number, month: number, day: number) {
         return null
     }
     return date
+}
+
+type ExplicitDateRange = {
+    startDate: Date
+    endDate: Date
+}
+
+function resolveCurrentMonthDayRange(
+    now: Date,
+    startDay: number,
+    endDay: number,
+): ExplicitDateRange | null {
+    if (!Number.isInteger(startDay) || !Number.isInteger(endDay)) return null
+    if (startDay < 1 || startDay > 31 || endDay < 1 || endDay > 31) return null
+
+    const currentYear = now.getUTCFullYear()
+    const currentMonth = now.getUTCMonth() + 1
+    const startDate = toValidUtcDate(currentYear, currentMonth, startDay)
+    if (!startDate) return null
+
+    if (endDay >= startDay) {
+        const endDate = toValidUtcDate(currentYear, currentMonth, endDay)
+        return endDate ? { startDate, endDate } : null
+    }
+
+    const nextMonth = new Date(Date.UTC(currentYear, now.getUTCMonth() + 1, 1))
+    const endDate = toValidUtcDate(
+        nextMonth.getUTCFullYear(),
+        nextMonth.getUTCMonth() + 1,
+        endDay,
+    )
+    return endDate ? { startDate, endDate } : null
+}
+
+function parseExplicitDateRange(
+    question: string,
+    now: Date,
+): ExplicitDateRange | null {
+    const contextualMatch =
+        question.match(
+            /\b(?:on|from|during|between)\s*(\d{1,2})\s*(?:-|–|—|to|through|thru)\s*(\d{1,2})\b/i,
+        ) ||
+        question.match(
+            /(?:ในวันที่|วันที่|วันที|ช่วงวันที่|ระหว่างวันที่)\s*(\d{1,2})\s*(?:-|–|—|ถึง)\s*(\d{1,2})/i,
+        )
+
+    if (contextualMatch) {
+        return resolveCurrentMonthDayRange(
+            now,
+            Number(contextualMatch[1]),
+            Number(contextualMatch[2]),
+        )
+    }
+
+    if (!DAILY_DISTRIBUTION_RE.test(question)) return null
+
+    const bareRangeMatch = question.match(
+        /(?:^|[^\d/])(\d{1,2})\s*(?:-|–|—|to|through|thru|ถึง)\s*(\d{1,2})(?=$|[^\d/])/i,
+    )
+    if (!bareRangeMatch) return null
+
+    return resolveCurrentMonthDayRange(
+        now,
+        Number(bareRangeMatch[1]),
+        Number(bareRangeMatch[2]),
+    )
 }
 
 function parseExplicitDate(question: string): Date | null {
@@ -304,17 +372,23 @@ export function resolveQuestionTimeRange(
     },
 ): QuestionTimeRange {
     const today = startOfUtcDay(opts?.now ?? new Date())
+    const explicitRange = parseExplicitDateRange(question, today)
     const explicitDate =
-        parseExplicitDate(question) ||
-        parseRelativeSingleDayDate(question, today) ||
-        getHintDate(opts?.hintedTransitDate ?? null)
-    const relativeRange = parseRelativeRange(question, today)
+        (explicitRange
+            ? null
+            : parseExplicitDate(question) ||
+              parseRelativeSingleDayDate(question, today) ||
+              getHintDate(opts?.hintedTransitDate ?? null))
+    const relativeRange = explicitRange ? null : parseRelativeRange(question, today)
 
-    const startDate = explicitDate ?? today
+    const startDate = explicitRange?.startDate ?? explicitDate ?? today
     let source: TimeRangeSource = "default_30d"
     let endDate = addDays(startDate, DEFAULT_FALLBACK_DAYS)
 
-    if (explicitDate && !relativeRange) {
+    if (explicitRange) {
+        endDate = explicitRange.endDate
+        source = "explicit"
+    } else if (explicitDate && !relativeRange) {
         endDate = addDays(startDate, 1)
         source = "explicit"
     } else if (relativeRange?.calendarEnd) {
@@ -329,9 +403,9 @@ export function resolveQuestionTimeRange(
         source = source === "default_30d" ? "explicit" : source
     }
 
-    if (endDate.getTime() <= startDate.getTime()) {
+    if (endDate.getTime() < startDate.getTime()) {
         endDate = addDays(startDate, DEFAULT_FALLBACK_DAYS)
-        source = explicitDate ? "explicit" : "default_30d"
+        source = explicitDate || explicitRange ? "explicit" : "default_30d"
     }
 
     const durationDays = normalizeDurationDays(startDate, endDate)

--- a/lib/astrology/single-day.ts
+++ b/lib/astrology/single-day.ts
@@ -1,5 +1,29 @@
 import type { TimeRangeSource } from "./question-time-range"
 
+const DAILY_DISTRIBUTION_RE =
+    /รายวัน|วันต่อวัน|\b(daily|day by day|each day|per day)\b|ແບບລາຍວັນ/i
+
+function looksLikeDayOfMonthRange(question: string): boolean {
+    if (
+        /\b(?:on|from|during|between)\s*\d{1,2}\s*(?:-|–|—|to|through|thru)\s*\d{1,2}\b/i.test(
+            question,
+        )
+    ) {
+        return true
+    }
+    if (
+        /(?:ในวันที่|วันที่|วันที|ช่วงวันที่|ระหว่างวันที่)\s*\d{1,2}\s*(?:-|–|—|ถึง)\s*\d{1,2}/i.test(
+            question,
+        )
+    ) {
+        return true
+    }
+    if (!DAILY_DISTRIBUTION_RE.test(question)) return false
+    return /(?:^|[^\d/])\d{1,2}\s*(?:-|–|—|to|through|thru|ถึง)\s*\d{1,2}(?=$|[^\d/])/i.test(
+        question,
+    )
+}
+
 /**
  * Minimal shape needed to decide single-day rendering. We keep this loose so
  * the helper can accept either the full `QuestionTimeRange` from the resolver
@@ -178,6 +202,7 @@ export function looksLikeNatalQuestion(question: string): boolean {
         return false
     }
     if (/(ໃນອີກ|ພາຍໃນ|ອີກ)\s*\d+\s*(ມື້|ອາທິດ|ເດືອນ|ປີ)/.test(trimmed)) return false
+    if (looksLikeDayOfMonthRange(trimmed)) return false
 
     // ISO date / slash date / Month-Day-Year long form.
     if (/\b(19|20)\d{2}-\d{1,2}-\d{1,2}\b/.test(trimmed)) return false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- teach the horoscope time-range resolver to treat shorthand day-of-month spans like `on 19-23` / `วันที่ 19-23` as an explicit multi-day window in the current month
- keep bare `19-23` parsing gated behind daily-distribution phrasing such as `daily` / `รายวัน` so these questions route to the timeline instead of falling back to the long-form question response
- update the client natal heuristic and add focused tests for the new shorthand range handling

## Testing
- `NODE_PATH=/tmp/cursor-test-stubs/node_modules npx tsx --test lib/astrology/__tests__/question-time-range.test.ts lib/astrology/__tests__/single-day.test.ts`
- attempted ESLint on touched files, but the cloud environment does not have the repo's installed dev dependencies available, so lint could not be executed here
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9fc422b-bb12-4a4e-8ff9-da6576072b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9fc422b-bb12-4a4e-8ff9-da6576072b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

