### PR TITLE
Add subscription paywall and plan-based card draw limits

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -171,6 +171,7 @@ function getChatDecisionPrompt({
     savedBirthInfo,
     hasStoredBirthChart,
     isAuthenticated,
+    planTier,
 }: {
     question: string
     history?: Array<{ role: "user" | "assistant"; text: string }>
@@ -179,6 +180,7 @@ function getChatDecisionPrompt({
     savedBirthInfo?: string | null
     hasStoredBirthChart?: boolean
     isAuthenticated: boolean
+    planTier?: "free" | "basic" | "pro"
 }) {
     const historyText =
         history && history.length
@@ -219,6 +221,12 @@ function getChatDecisionPrompt({
         ? `\nNote: The user is NOT signed in. Horoscope readings ultimately require an account, but you should STILL classify timing/astrology questions as "horoscope" so the app can show a sign-in prompt. Do not pretend the topic is "chat" just to avoid the auth requirement — the client handles the sign-in gate separately.\n`
         : ""
 
+    const effectivePlanTier = planTier ?? "free"
+    const planTierRule =
+        effectivePlanTier === "free"
+            ? `\nUser plan: FREE tier. The free tier is LIMITED TO A MAXIMUM OF 3 CARDS per draw. If type is "draw", you MUST choose only "simple" (1 card) or "general" (3 cards). Do NOT choose "detailed" (5), "expanded" (7), or "celtic" (10) for free-tier users — the client will downgrade them anyway.\n`
+            : `\nUser plan: ${effectivePlanTier.toUpperCase()} tier. The user has access to all spread sizes (up to 10 cards).\n`
+
     return `
 ${contextBlock}Recent conversation:
 ${historyText}
@@ -226,7 +234,7 @@ ${historyText}
 User message:
 ${question}
 ${modeInstruction}
-${savedBirthBlock}${storedChartBlock}${anonymousHoroscopeRule}
+${savedBirthBlock}${storedChartBlock}${anonymousHoroscopeRule}${planTierRule}
 DETECTED LANGUAGE: The user's message is in ${detectedLang}. Ignore the language of conversation history — only the current user message language matters.
 
 Classify the intent and return JSON.
@@ -266,6 +274,7 @@ export async function POST(req: Request) {
             hasStoredBirthChart?: boolean
             interpretationMode?: string | null
             contextSummary?: string | null
+            planTier?: "free" | "basic" | "pro"
         }
         try {
             body = await req.json()
@@ -281,7 +290,12 @@ export async function POST(req: Request) {
             contextSummary,
             savedBirthInfo,
             hasStoredBirthChart,
+            planTier: rawPlanTier,
         } = body ?? {}
+        const planTier =
+            rawPlanTier === "basic" || rawPlanTier === "pro"
+                ? rawPlanTier
+                : "free"
 
         const user = await getUserFromBearer(req)
         const isAuthenticated = Boolean(user)
@@ -309,6 +323,7 @@ export async function POST(req: Request) {
                 savedBirthInfo,
                 hasStoredBirthChart: Boolean(hasStoredBirthChart),
                 isAuthenticated,
+                planTier,
             }),
         })
 

--- a/components/chat/draw-card-section.tsx
+++ b/components/chat/draw-card-section.tsx
@@ -9,16 +9,24 @@ import {
     Minus,
     Plus,
     Sparkles,
+    Lock,
 } from "lucide-react"
 import type { RefObject } from "react"
 import { useTranslations } from "next-intl"
 import { LinearCardSpread } from "@/components/tarot/card-selection/linear-card-spread"
 import { ManualCardSelectionDialog } from "@/components/tarot/card-selection/manual-card-selection-dialog"
+import { ManualPickPaywallDialog } from "@/components/tarot/card-selection/manual-pick-paywall-dialog"
 import {
     Popover,
     PopoverTrigger,
     PopoverContent,
 } from "@/components/ui/popover"
+import type { SubscriptionPlanTier } from "@/lib/payments/subscription-plans"
+import {
+    PAID_TIER_MAX_CARDS,
+    getMaxCardsForTier,
+    canUseManualCardPick,
+} from "@/lib/payments/plan-limits"
 import type { CardUiText } from "./types"
 
 type DrawCardSectionProps = {
@@ -36,6 +44,7 @@ type DrawCardSectionProps = {
     onProvideSelectByIndices: (fn: (indices: number[]) => void) => void
     selectionResetSignal: number
     containerRef?: RefObject<HTMLDivElement | null>
+    planTier?: SubscriptionPlanTier | "free" | null
 }
 
 export default function DrawCardSection({
@@ -53,10 +62,17 @@ export default function DrawCardSection({
     onProvideSelectByIndices,
     selectionResetSignal,
     containerRef,
+    planTier,
 }: DrawCardSectionProps) {
     const t = useTranslations("ReadingPage.chooseCards")
     const [manualDialogOpen, setManualDialogOpen] = useState(false)
+    const [paywallDialogOpen, setPaywallDialogOpen] = useState(false)
     const [popoverOpen, setPopoverOpen] = useState(false)
+    const maxCards = getMaxCardsForTier(planTier)
+    const manualPickUnlocked = canUseManualCardPick(planTier)
+    const atMaxLimit = cardsToSelect >= maxCards
+    const upgradeForMoreCards =
+        atMaxLimit && maxCards < PAID_TIER_MAX_CARDS
 
     return (
         <div
@@ -115,11 +131,20 @@ export default function DrawCardSection({
                                 className='flex items-center gap-3 w-full rounded-lg px-3 py-2.5 text-sm text-white/90 hover:bg-white/10 transition-colors text-left'
                                 onClick={() => {
                                     setPopoverOpen(false)
-                                    setManualDialogOpen(true)
+                                    if (manualPickUnlocked) {
+                                        setManualDialogOpen(true)
+                                    } else {
+                                        setPaywallDialogOpen(true)
+                                    }
                                 }}
                             >
                                 <Hand className='w-4 h-4 text-purple-300' />
-                                {t("manualSelect")}
+                                <span className='flex-1'>
+                                    {t("manualSelect")}
+                                </span>
+                                {!manualPickUnlocked && (
+                                    <Lock className='w-3.5 h-3.5 text-white/40' />
+                                )}
                             </button>
                             <div className='mt-1 border-t border-white/10 px-3 py-2'>
                                 <p className='text-xs text-white/60'>
@@ -145,17 +170,38 @@ export default function DrawCardSection({
                                     <button
                                         type='button'
                                         className='flex h-8 w-8 items-center justify-center rounded-full border border-white/10 text-white/80 transition-colors hover:border-white/30 hover:text-white disabled:opacity-40'
-                                        onClick={() =>
+                                        onClick={() => {
+                                            if (upgradeForMoreCards) {
+                                                setPopoverOpen(false)
+                                                setPaywallDialogOpen(true)
+                                                return
+                                            }
                                             onCardsToSelectChange(
-                                                Math.min(10, cardsToSelect + 1),
+                                                Math.min(
+                                                    maxCards,
+                                                    cardsToSelect + 1,
+                                                ),
                                             )
+                                        }}
+                                        disabled={
+                                            cardsToSelect >= PAID_TIER_MAX_CARDS
                                         }
-                                        disabled={cardsToSelect >= 10}
                                         aria-label={cardUi.increaseCardCount}
                                     >
-                                        <Plus className='w-4 h-4' />
+                                        {upgradeForMoreCards ? (
+                                            <Lock className='w-3.5 h-3.5' />
+                                        ) : (
+                                            <Plus className='w-4 h-4' />
+                                        )}
                                     </button>
                                 </div>
+                                {upgradeForMoreCards && (
+                                    <p className='mt-2 text-[10px] text-purple-200/70 leading-snug'>
+                                        {t("freeTierMaxCardsHint", {
+                                            max: maxCards,
+                                        })}
+                                    </p>
+                                )}
                             </div>
                         </PopoverContent>
                     </Popover>
@@ -178,6 +224,12 @@ export default function DrawCardSection({
                 onOpenChange={setManualDialogOpen}
                 cardsToSelect={cardsToSelect}
                 onCardsSelected={onCardsSelected}
+            />
+
+            <ManualPickPaywallDialog
+                open={paywallDialogOpen}
+                onOpenChange={setPaywallDialogOpen}
+                currentTier={planTier ?? "free"}
             />
         </div>
     )

--- a/components/chat/draw-card-section.tsx
+++ b/components/chat/draw-card-section.tsx
@@ -15,7 +15,7 @@ import type { RefObject } from "react"
 import { useTranslations } from "next-intl"
 import { LinearCardSpread } from "@/components/tarot/card-selection/linear-card-spread"
 import { ManualCardSelectionDialog } from "@/components/tarot/card-selection/manual-card-selection-dialog"
-import { ManualPickPaywallDialog } from "@/components/tarot/card-selection/manual-pick-paywall-dialog"
+import { PaywallDialog } from "@/components/subscription/paywall-dialog"
 import {
     Popover,
     PopoverTrigger,
@@ -226,10 +226,17 @@ export default function DrawCardSection({
                 onCardsSelected={onCardsSelected}
             />
 
-            <ManualPickPaywallDialog
+            <PaywallDialog
                 open={paywallDialogOpen}
                 onOpenChange={setPaywallDialogOpen}
+                requiredTier='basic'
                 currentTier={planTier ?? "free"}
+                title={t("manualPickPaywallTitle")}
+                description={t("manualPickPaywallDesc")}
+                feature={t("manualPickPaywallFeature")}
+                icon={<Hand className='h-6 w-6 text-indigo-300' />}
+                footnote={t("manualPickPaywallNote")}
+                insufficientLabel={t("manualPickPaywallInsufficient")}
             />
         </div>
     )

--- a/components/chat/session.tsx
+++ b/components/chat/session.tsx
@@ -93,6 +93,10 @@ import type {
 import { parseQuestionDomain } from "@/lib/chat/situation-schema"
 
 import { getTarotCardCount } from "@/lib/chat/decision-schema"
+import {
+    clampCardCountToTier,
+    getMaxCardsForTier,
+} from "@/lib/payments/plan-limits"
 import { buildSupportBlockFromDecision } from "@/lib/chat/support-block"
 import { useAuth } from "@/hooks/use-auth"
 import { useActiveSubscription } from "@/hooks/use-active-subscription"
@@ -2325,13 +2329,18 @@ export default function ChatSession({
     const hasAssistantResponse = messages.some(
         (message) => message.role === "assistant",
     )
+    const planTier = subscription?.tier ?? "free"
     const defaultCardsToSelect = useMemo(
-        () => decision?.cardCount ?? 0,
-        [decision],
+        () => clampCardCountToTier(decision?.cardCount ?? 0, planTier),
+        [decision, planTier],
     )
     const cardsToSelect = useMemo(
-        () => cardCountOverride ?? defaultCardsToSelect,
-        [cardCountOverride, defaultCardsToSelect],
+        () =>
+            clampCardCountToTier(
+                cardCountOverride ?? defaultCardsToSelect,
+                planTier,
+            ),
+        [cardCountOverride, defaultCardsToSelect, planTier],
     )
     const isChatLoading = consulting || isInterpreting
 
@@ -2779,23 +2788,38 @@ export default function ChatSession({
         [interpretationMode, user],
     )
 
-    const normalizeDrawDecision = useCallback((decision: ChatDecision) => {
-        if (decision.type !== "draw") {
+    const normalizeDrawDecision = useCallback(
+        (decision: ChatDecision) => {
+            if (decision.type !== "draw") {
+                return {
+                    ...decision,
+                    spreadType: undefined,
+                    cardCount: undefined,
+                    spreadReason: undefined,
+                }
+            }
+
+            const rawSpreadType = decision.spreadType ?? "simple"
+            const rawCount = getTarotCardCount(rawSpreadType)
+            const tierMax = getMaxCardsForTier(planTier)
+            if (rawCount <= tierMax) {
+                return {
+                    ...decision,
+                    spreadType: rawSpreadType,
+                    cardCount: rawCount,
+                }
+            }
+            // Free tier hit: collapse to the largest spread that fits.
+            // Allowed spread types (in ascending card count): simple(1), general(3).
+            const downgradedSpread = tierMax >= 3 ? "general" : "simple"
             return {
                 ...decision,
-                spreadType: undefined,
-                cardCount: undefined,
-                spreadReason: undefined,
+                spreadType: downgradedSpread,
+                cardCount: getTarotCardCount(downgradedSpread),
             }
-        }
-
-        const spreadType = decision.spreadType ?? "simple"
-        return {
-            ...decision,
-            spreadType,
-            cardCount: getTarotCardCount(spreadType),
-        }
-    }, [])
+        },
+        [planTier],
+    )
 
     const getDefaultSystemByLocale = useCallback(() => {
         return getDefaultAstrologySystem(
@@ -3768,6 +3792,7 @@ export default function ChatSession({
                     hasStoredBirthChart: Boolean(storedBirthChart),
                     interpretationMode: modeForApi,
                     contextSummary: contextSummary || undefined,
+                    planTier,
                 }),
                 signal: abortControllerRef.current.signal,
             })
@@ -3804,6 +3829,7 @@ export default function ChatSession({
             storedBirthChart,
             user,
             originContext,
+            planTier,
         ],
     )
 
@@ -5107,9 +5133,10 @@ export default function ChatSession({
 
     const handleCardsToSelectChange = useCallback(
         (nextCount: number) => {
+            const tierMax = getMaxCardsForTier(planTier)
             const boundedCount = Math.max(
                 1,
-                Math.min(10, Math.floor(nextCount)),
+                Math.min(tierMax, Math.floor(nextCount)),
             )
             setCardCountOverride(
                 boundedCount === defaultCardsToSelect ? null : boundedCount,
@@ -5119,7 +5146,7 @@ export default function ChatSession({
                 setCardSelectionResetSignal((prev) => prev + 1)
             }
         },
-        [defaultCardsToSelect, selectedCount],
+        [defaultCardsToSelect, selectedCount, planTier],
     )
 
     const cardDrawSection = canShowCardDrawSection ? (
@@ -5138,6 +5165,7 @@ export default function ChatSession({
             onProvideRandomPick={(fn) => setPickFn(() => fn)}
             onProvideSelectByIndices={(fn) => setSelectByIndicesFn(() => fn)}
             selectionResetSignal={cardSelectionResetSignal}
+            planTier={planTier}
         />
     ) : null
 

--- a/components/subscription/paywall-dialog.tsx
+++ b/components/subscription/paywall-dialog.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useState } from "react"
+import { useState, type ReactNode } from "react"
 import { useLocale, useTranslations } from "next-intl"
-import { CheckCircle2, Crown, Hand, Lock, Star } from "lucide-react"
+import { CheckCircle2, Crown, Lock, Sparkles, Star } from "lucide-react"
 import {
     Dialog,
     DialogContent,
@@ -24,22 +24,53 @@ import {
 } from "@/lib/payments/currency-utils"
 import { cn } from "@/lib/utils"
 
-type ManualPickPaywallDialogProps = {
-    open: boolean
-    onOpenChange: (open: boolean) => void
-    currentTier?: SubscriptionPlanTier | "free" | null
+export type PaywallTier = SubscriptionPlanTier | "free"
+
+const TIER_RANK: Record<PaywallTier, number> = {
+    free: 0,
+    basic: 1,
+    pro: 2,
 }
 
-export function ManualPickPaywallDialog({
+export type PaywallDialogProps = {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    /** Minimum subscription tier that unlocks the gated feature. */
+    requiredTier: SubscriptionPlanTier
+    /** The user's current tier; used to label "Current plan". */
+    currentTier?: PaywallTier | null
+    /** Dialog title. */
+    title: string
+    /** Short description shown beneath the title. */
+    description: string
+    /** A single-line label describing what the feature is. */
+    feature: string
+    /** Optional icon shown above the title. Defaults to a sparkles icon. */
+    icon?: ReactNode
+    /** Optional small note rendered at the bottom of the dialog. */
+    footnote?: string
+    /** Label shown on a disabled plan card that doesn't satisfy the gate. */
+    insufficientLabel?: string
+}
+
+export function PaywallDialog({
     open,
     onOpenChange,
+    requiredTier,
     currentTier,
-}: ManualPickPaywallDialogProps) {
+    title,
+    description,
+    feature,
+    icon,
+    footnote,
+    insufficientLabel,
+}: PaywallDialogProps) {
     const t = useTranslations("Pricing")
-    const tCards = useTranslations("ReadingPage.chooseCards")
     const locale = useLocale()
     const currency: CurrencyCode = locale === "th" ? "THB" : "USD"
     const [billingCycle, setBillingCycle] = useState<BillingCycle>("monthly")
+
+    const requiredRank = TIER_RANK[requiredTier]
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -47,14 +78,16 @@ export function ManualPickPaywallDialog({
                 <DialogHeader className='px-6 pt-6 pb-2'>
                     <div className='flex items-center justify-center mb-2'>
                         <span className='inline-flex items-center justify-center h-12 w-12 rounded-2xl bg-indigo-500/15 border border-indigo-500/25'>
-                            <Hand className='h-6 w-6 text-indigo-300' />
+                            {icon ?? (
+                                <Sparkles className='h-6 w-6 text-indigo-300' />
+                            )}
                         </span>
                     </div>
                     <DialogTitle className='text-white text-center text-xl'>
-                        {tCards("manualPickPaywallTitle")}
+                        {title}
                     </DialogTitle>
                     <DialogDescription className='text-center text-purple-200/70'>
-                        {tCards("manualPickPaywallDesc")}
+                        {description}
                     </DialogDescription>
                 </DialogHeader>
 
@@ -122,7 +155,7 @@ export function ManualPickPaywallDialog({
                                       )
                                     : null
 
-                            const unlocksManualPick = tier === "pro"
+                            const meetsGate = TIER_RANK[tier] >= requiredRank
                             const isCurrent = currentTier === tier
 
                             return (
@@ -130,7 +163,7 @@ export function ManualPickPaywallDialog({
                                     key={plan.id}
                                     className={cn(
                                         "relative flex flex-col gap-3 rounded-2xl border p-4",
-                                        unlocksManualPick
+                                        meetsGate
                                             ? "border-indigo-400/40 bg-indigo-500/10 shadow-lg shadow-indigo-500/10"
                                             : "border-white/10 bg-black/30 opacity-80",
                                     )}
@@ -140,7 +173,7 @@ export function ManualPickPaywallDialog({
                                             <Crown
                                                 className={cn(
                                                     "h-4 w-4",
-                                                    unlocksManualPick
+                                                    meetsGate
                                                         ? "text-indigo-300"
                                                         : "text-white/40",
                                                 )}
@@ -196,20 +229,18 @@ export function ManualPickPaywallDialog({
 
                                     <ul className='space-y-1 text-[11px] text-white/75'>
                                         <li className='flex items-center gap-1.5'>
-                                            {unlocksManualPick ? (
+                                            {meetsGate ? (
                                                 <CheckCircle2 className='h-3 w-3 text-indigo-300 shrink-0' />
                                             ) : (
                                                 <Lock className='h-3 w-3 text-white/40 shrink-0' />
                                             )}
                                             <span
                                                 className={cn(
-                                                    !unlocksManualPick &&
+                                                    !meetsGate &&
                                                         "text-white/50",
                                                 )}
                                             >
-                                                {tCards(
-                                                    "manualPickPaywallFeature",
-                                                )}
+                                                {feature}
                                             </span>
                                         </li>
                                         <li className='flex items-center gap-1.5'>
@@ -222,7 +253,7 @@ export function ManualPickPaywallDialog({
                                         </li>
                                     </ul>
 
-                                    {unlocksManualPick ? (
+                                    {meetsGate ? (
                                         <Checkout
                                             mode='subscribe'
                                             plan={billingCycle}
@@ -237,9 +268,8 @@ export function ManualPickPaywallDialog({
                                         >
                                             {isCurrent
                                                 ? t("currentPlan")
-                                                : tCards(
-                                                      "manualPickPaywallInsufficient",
-                                                  )}
+                                                : (insufficientLabel ??
+                                                  t("upgradePlan"))}
                                         </button>
                                     )}
                                 </div>
@@ -247,9 +277,11 @@ export function ManualPickPaywallDialog({
                         })}
                     </div>
 
-                    <p className='text-center text-[11px] text-white/50'>
-                        {tCards("manualPickPaywallNote")}
-                    </p>
+                    {footnote && (
+                        <p className='text-center text-[11px] text-white/50'>
+                            {footnote}
+                        </p>
+                    )}
                 </div>
             </DialogContent>
         </Dialog>

--- a/components/tarot/card-selection/manual-pick-paywall-dialog.tsx
+++ b/components/tarot/card-selection/manual-pick-paywall-dialog.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import { useState } from "react"
+import { useLocale, useTranslations } from "next-intl"
+import { CheckCircle2, Crown, Hand, Lock, Star } from "lucide-react"
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog"
+import { Checkout } from "@/components/checkout"
+import {
+    SUBSCRIPTION_PLANS,
+    resolvePlanBillingPrice,
+    resolvePlanPriceId,
+    type BillingCycle,
+    type SubscriptionPlanTier,
+} from "@/lib/payments/subscription-plans"
+import {
+    formatCurrency,
+    type CurrencyCode,
+} from "@/lib/payments/currency-utils"
+import { cn } from "@/lib/utils"
+
+type ManualPickPaywallDialogProps = {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    currentTier?: SubscriptionPlanTier | "free" | null
+}
+
+export function ManualPickPaywallDialog({
+    open,
+    onOpenChange,
+    currentTier,
+}: ManualPickPaywallDialogProps) {
+    const t = useTranslations("Pricing")
+    const tCards = useTranslations("ReadingPage.chooseCards")
+    const locale = useLocale()
+    const currency: CurrencyCode = locale === "th" ? "THB" : "USD"
+    const [billingCycle, setBillingCycle] = useState<BillingCycle>("monthly")
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className='!max-w-2xl bg-gradient-to-b from-[#0a0a1a] to-[#1a0b2e] border-purple-500/20 text-white p-0 overflow-hidden'>
+                <DialogHeader className='px-6 pt-6 pb-2'>
+                    <div className='flex items-center justify-center mb-2'>
+                        <span className='inline-flex items-center justify-center h-12 w-12 rounded-2xl bg-indigo-500/15 border border-indigo-500/25'>
+                            <Hand className='h-6 w-6 text-indigo-300' />
+                        </span>
+                    </div>
+                    <DialogTitle className='text-white text-center text-xl'>
+                        {tCards("manualPickPaywallTitle")}
+                    </DialogTitle>
+                    <DialogDescription className='text-center text-purple-200/70'>
+                        {tCards("manualPickPaywallDesc")}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className='px-6 pb-6 space-y-4'>
+                    <div className='flex items-center justify-center'>
+                        <div className='inline-flex rounded-full bg-white/5 border border-white/10 p-0.5'>
+                            {(["monthly", "annual"] as BillingCycle[]).map(
+                                (cycle) => (
+                                    <button
+                                        key={cycle}
+                                        type='button'
+                                        onClick={() => setBillingCycle(cycle)}
+                                        className={cn(
+                                            "px-5 py-1.5 rounded-full text-sm font-medium transition-all duration-200",
+                                            billingCycle === cycle
+                                                ? "bg-indigo-500/80 text-white shadow-lg shadow-indigo-500/25"
+                                                : "text-white/60 hover:text-white/90",
+                                        )}
+                                    >
+                                        {cycle === "monthly"
+                                            ? t("monthly")
+                                            : t("yearly")}
+                                    </button>
+                                ),
+                            )}
+                        </div>
+                    </div>
+
+                    <div className='grid gap-3 sm:grid-cols-2'>
+                        {SUBSCRIPTION_PLANS.map((plan) => {
+                            const tier = plan.id as SubscriptionPlanTier
+                            const billing = plan.billing?.[billingCycle]
+                            const priceId = resolvePlanPriceId(
+                                plan,
+                                billingCycle,
+                                currency,
+                            )
+                            const monthlyNative = resolvePlanBillingPrice(
+                                plan,
+                                "monthly",
+                                currency,
+                            )
+                            const annualNative = resolvePlanBillingPrice(
+                                plan,
+                                "annual",
+                                currency,
+                            )
+                            const annualMonthlyPrice =
+                                annualNative != null
+                                    ? annualNative / 12
+                                    : undefined
+                            const displayPrice =
+                                billingCycle === "annual"
+                                    ? annualMonthlyPrice
+                                    : monthlyNative
+                            const discountPercent =
+                                billingCycle === "annual" &&
+                                monthlyNative != null &&
+                                annualMonthlyPrice != null
+                                    ? Math.round(
+                                          (1 -
+                                              annualMonthlyPrice /
+                                                  monthlyNative) *
+                                              100,
+                                      )
+                                    : null
+
+                            const unlocksManualPick = tier === "pro"
+                            const isCurrent = currentTier === tier
+
+                            return (
+                                <div
+                                    key={plan.id}
+                                    className={cn(
+                                        "relative flex flex-col gap-3 rounded-2xl border p-4",
+                                        unlocksManualPick
+                                            ? "border-indigo-400/40 bg-indigo-500/10 shadow-lg shadow-indigo-500/10"
+                                            : "border-white/10 bg-black/30 opacity-80",
+                                    )}
+                                >
+                                    <div className='flex items-center justify-between gap-2'>
+                                        <div className='flex items-center gap-2'>
+                                            <Crown
+                                                className={cn(
+                                                    "h-4 w-4",
+                                                    unlocksManualPick
+                                                        ? "text-indigo-300"
+                                                        : "text-white/40",
+                                                )}
+                                            />
+                                            <span className='text-base font-semibold text-white'>
+                                                {t(plan.nameKey)}
+                                            </span>
+                                        </div>
+                                        {plan.badgeKey && (
+                                            <span className='inline-flex rounded-full bg-indigo-500/20 border border-indigo-500/30 px-2 py-[1px] text-[9px] font-bold tracking-widest uppercase text-indigo-200'>
+                                                {t(plan.badgeKey)}
+                                            </span>
+                                        )}
+                                    </div>
+
+                                    <div className='flex items-baseline gap-1.5'>
+                                        <Star className='h-3.5 w-3.5 fill-yellow-400 text-yellow-400 shrink-0' />
+                                        <span className='text-lg font-bold text-white'>
+                                            {billing?.stars}
+                                        </span>
+                                        <span className='text-[10px] uppercase tracking-widest text-white/60'>
+                                            {billingCycle === "monthly"
+                                                ? t("starsPerMonth")
+                                                : t("starsPerYear")}
+                                        </span>
+                                    </div>
+
+                                    <div className='flex items-baseline gap-1.5'>
+                                        <span className='text-2xl font-bold text-white'>
+                                            {displayPrice != null
+                                                ? formatCurrency(
+                                                      displayPrice,
+                                                      currency,
+                                                      locale,
+                                                  )
+                                                : "--"}
+                                        </span>
+                                        <span className='text-xs text-white/60'>
+                                            /{t("perMonth")}
+                                        </span>
+                                    </div>
+
+                                    {billingCycle === "annual" &&
+                                        discountPercent != null &&
+                                        discountPercent > 0 && (
+                                            <div className='inline-flex w-fit rounded-full bg-emerald-500/15 border border-emerald-500/25 px-2 py-[1px] text-[10px] font-medium text-emerald-200'>
+                                                {t("savePercent", {
+                                                    percent: discountPercent,
+                                                })}{" "}
+                                                {t("billedYearly")}
+                                            </div>
+                                        )}
+
+                                    <ul className='space-y-1 text-[11px] text-white/75'>
+                                        <li className='flex items-center gap-1.5'>
+                                            {unlocksManualPick ? (
+                                                <CheckCircle2 className='h-3 w-3 text-indigo-300 shrink-0' />
+                                            ) : (
+                                                <Lock className='h-3 w-3 text-white/40 shrink-0' />
+                                            )}
+                                            <span
+                                                className={cn(
+                                                    !unlocksManualPick &&
+                                                        "text-white/50",
+                                                )}
+                                            >
+                                                {tCards(
+                                                    "manualPickPaywallFeature",
+                                                )}
+                                            </span>
+                                        </li>
+                                        <li className='flex items-center gap-1.5'>
+                                            <CheckCircle2 className='h-3 w-3 text-indigo-300 shrink-0' />
+                                            {t("bonusStars")}
+                                        </li>
+                                        <li className='flex items-center gap-1.5'>
+                                            <CheckCircle2 className='h-3 w-3 text-indigo-300 shrink-0' />
+                                            {t("cancelFromAccount")}
+                                        </li>
+                                    </ul>
+
+                                    {unlocksManualPick ? (
+                                        <Checkout
+                                            mode='subscribe'
+                                            plan={billingCycle}
+                                            packId={priceId}
+                                            className='w-full'
+                                        />
+                                    ) : (
+                                        <button
+                                            type='button'
+                                            disabled
+                                            className='w-full rounded-full bg-white/5 text-white/40 cursor-not-allowed px-4 py-2 text-sm font-semibold border border-white/10'
+                                        >
+                                            {isCurrent
+                                                ? t("currentPlan")
+                                                : tCards(
+                                                      "manualPickPaywallInsufficient",
+                                                  )}
+                                        </button>
+                                    )}
+                                </div>
+                            )
+                        })}
+                    </div>
+
+                    <p className='text-center text-[11px] text-white/50'>
+                        {tCards("manualPickPaywallNote")}
+                    </p>
+                </div>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/lib/payments/plan-limits.ts
+++ b/lib/payments/plan-limits.ts
@@ -13,7 +13,7 @@ export function getMaxCardsForTier(tier: PlanTier | null | undefined): number {
 export function canUseManualCardPick(
     tier: PlanTier | null | undefined,
 ): boolean {
-    return tier === "pro"
+    return tier === "basic" || tier === "pro"
 }
 
 export function clampCardCountToTier(

--- a/lib/payments/plan-limits.ts
+++ b/lib/payments/plan-limits.ts
@@ -1,0 +1,26 @@
+import type { SubscriptionPlanTier } from "@/lib/payments/subscription-plans"
+
+export type PlanTier = SubscriptionPlanTier | "free"
+
+export const FREE_TIER_MAX_CARDS = 3
+export const PAID_TIER_MAX_CARDS = 10
+
+export function getMaxCardsForTier(tier: PlanTier | null | undefined): number {
+    if (!tier || tier === "free") return FREE_TIER_MAX_CARDS
+    return PAID_TIER_MAX_CARDS
+}
+
+export function canUseManualCardPick(
+    tier: PlanTier | null | undefined,
+): boolean {
+    return tier === "pro"
+}
+
+export function clampCardCountToTier(
+    count: number,
+    tier: PlanTier | null | undefined,
+): number {
+    const max = getMaxCardsForTier(tier)
+    if (!Number.isFinite(count) || count <= 0) return count
+    return Math.min(count, max)
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1461,10 +1461,10 @@
       "upright": "Upright",
       "reversedTab": "Reversed",
       "freeTierMaxCardsHint": "Free plan can draw up to {max} cards. Upgrade for more.",
-      "manualPickPaywallTitle": "Manual card pick is a Pro feature",
-      "manualPickPaywallDesc": "Choose any card you like from the full deck. Upgrade to Pro to unlock — checkout is powered by Stripe on the next page.",
+      "manualPickPaywallTitle": "Manual card pick is a subscriber feature",
+      "manualPickPaywallDesc": "Choose any card you like from the full deck. Upgrade to Basic or Pro to unlock — checkout is powered by Stripe on the next page.",
       "manualPickPaywallFeature": "Manual card selection from the full deck",
-      "manualPickPaywallInsufficient": "Not included on Basic",
+      "manualPickPaywallInsufficient": "Upgrade required",
       "manualPickPaywallNote": "Selecting a plan takes you to secure Stripe checkout."
     },
     "editQuestion": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1459,7 +1459,13 @@
       "pentacles": "Pentacles",
       "manualSelected": "{selected} of {total} selected",
       "upright": "Upright",
-      "reversedTab": "Reversed"
+      "reversedTab": "Reversed",
+      "freeTierMaxCardsHint": "Free plan can draw up to {max} cards. Upgrade for more.",
+      "manualPickPaywallTitle": "Manual card pick is a Pro feature",
+      "manualPickPaywallDesc": "Choose any card you like from the full deck. Upgrade to Pro to unlock — checkout is powered by Stripe on the next page.",
+      "manualPickPaywallFeature": "Manual card selection from the full deck",
+      "manualPickPaywallInsufficient": "Not included on Basic",
+      "manualPickPaywallNote": "Selecting a plan takes you to secure Stripe checkout."
     },
     "editQuestion": {
       "title": "Edit Your Question",

--- a/messages/lo.json
+++ b/messages/lo.json
@@ -1471,7 +1471,13 @@
       "pentacles": "ຫຼຽນ",
       "manualSelected": "{selected} ຈາກ {total} ທີ່ເລືອກແລ້ວ",
       "upright": "ໜ້າຕັ້ງ",
-      "reversedTab": "ກັບຫົວ"
+      "reversedTab": "ກັບຫົວ",
+      "freeTierMaxCardsHint": "ແພັກເກດຟຣີຈັ່ວໄດ້ສູງສຸດ {max} ໃບ. ອັບເກຣດເພື່ອຈັ່ວໄດ້ຫຼາຍຂຶ້ນ",
+      "manualPickPaywallTitle": "ການເລືອກໄພ່ດ້ວຍຕົນເອງເປັນຄຸນສົມບັດຂອງ Pro",
+      "manualPickPaywallDesc": "ເລືອກໄພ່ໃບໃດກໍ່ໄດ້ຈາກສຳຫຼັບເຕັມ. ອັບເກຣດເປັນ Pro ເພື່ອປົດລັອກ — ຊຳລະເງິນຜ່ານ Stripe ໃນໜ້າຕໍ່ໄປ",
+      "manualPickPaywallFeature": "ເລືອກໄພ່ດ້ວຍຕົນເອງຈາກສຳຫຼັບເຕັມ",
+      "manualPickPaywallInsufficient": "ບໍ່ລວມຢູ່ໃນແພັກເກດ Basic",
+      "manualPickPaywallNote": "ເລືອກແພັກເກດເພື່ອໄປຍັງໜ້າຊຳລະເງິນ Stripe ທີ່ປອດໄພ"
     },
     "editQuestion": {
       "title": "ແກ້ໄຂຄຳຖາມຂອງທ່ານ",

--- a/messages/lo.json
+++ b/messages/lo.json
@@ -1473,10 +1473,10 @@
       "upright": "ໜ້າຕັ້ງ",
       "reversedTab": "ກັບຫົວ",
       "freeTierMaxCardsHint": "ແພັກເກດຟຣີຈັ່ວໄດ້ສູງສຸດ {max} ໃບ. ອັບເກຣດເພື່ອຈັ່ວໄດ້ຫຼາຍຂຶ້ນ",
-      "manualPickPaywallTitle": "ການເລືອກໄພ່ດ້ວຍຕົນເອງເປັນຄຸນສົມບັດຂອງ Pro",
-      "manualPickPaywallDesc": "ເລືອກໄພ່ໃບໃດກໍ່ໄດ້ຈາກສຳຫຼັບເຕັມ. ອັບເກຣດເປັນ Pro ເພື່ອປົດລັອກ — ຊຳລະເງິນຜ່ານ Stripe ໃນໜ້າຕໍ່ໄປ",
+      "manualPickPaywallTitle": "ການເລືອກໄພ່ດ້ວຍຕົນເອງສຳລັບສະມາຊິກເທົ່ານັ້ນ",
+      "manualPickPaywallDesc": "ເລືອກໄພ່ໃບໃດກໍ່ໄດ້ຈາກສຳຫຼັບເຕັມ. ອັບເກຣດເປັນ Basic ຫຼື Pro ເພື່ອປົດລັອກ — ຊຳລະເງິນຜ່ານ Stripe ໃນໜ້າຕໍ່ໄປ",
       "manualPickPaywallFeature": "ເລືອກໄພ່ດ້ວຍຕົນເອງຈາກສຳຫຼັບເຕັມ",
-      "manualPickPaywallInsufficient": "ບໍ່ລວມຢູ່ໃນແພັກເກດ Basic",
+      "manualPickPaywallInsufficient": "ຕ້ອງອັບເກຣດແພັກເກດ",
       "manualPickPaywallNote": "ເລືອກແພັກເກດເພື່ອໄປຍັງໜ້າຊຳລະເງິນ Stripe ທີ່ປອດໄພ"
     },
     "editQuestion": {

--- a/messages/th.json
+++ b/messages/th.json
@@ -1474,10 +1474,10 @@
       "upright": "หน้าตั้ง",
       "reversedTab": "กลับหัว",
       "freeTierMaxCardsHint": "แพ็กเกจฟรีจั่วได้สูงสุด {max} ใบ อัปเกรดเพื่อจั่วได้มากขึ้น",
-      "manualPickPaywallTitle": "การเลือกไพ่ด้วยตนเองเป็นฟีเจอร์ของ Pro",
-      "manualPickPaywallDesc": "เลือกไพ่ใบใดก็ได้จากสำรับเต็ม อัปเกรดเป็น Pro เพื่อปลดล็อก — ชำระเงินผ่าน Stripe ในหน้าต่อไป",
+      "manualPickPaywallTitle": "การเลือกไพ่ด้วยตนเองสำหรับสมาชิกเท่านั้น",
+      "manualPickPaywallDesc": "เลือกไพ่ใบใดก็ได้จากสำรับเต็ม อัปเกรดเป็น Basic หรือ Pro เพื่อปลดล็อก — ชำระเงินผ่าน Stripe ในหน้าต่อไป",
       "manualPickPaywallFeature": "เลือกไพ่ด้วยตนเองจากสำรับเต็ม",
-      "manualPickPaywallInsufficient": "ไม่รวมในแพ็กเกจ Basic",
+      "manualPickPaywallInsufficient": "ต้องอัปเกรดแพ็กเกจ",
       "manualPickPaywallNote": "เลือกแพ็กเกจเพื่อไปยังหน้าชำระเงิน Stripe ที่ปลอดภัย"
     },
     "editQuestion": {

--- a/messages/th.json
+++ b/messages/th.json
@@ -1472,7 +1472,13 @@
       "pentacles": "เหรียญ",
       "manualSelected": "{selected} จาก {total} ที่เลือกแล้ว",
       "upright": "หน้าตั้ง",
-      "reversedTab": "กลับหัว"
+      "reversedTab": "กลับหัว",
+      "freeTierMaxCardsHint": "แพ็กเกจฟรีจั่วได้สูงสุด {max} ใบ อัปเกรดเพื่อจั่วได้มากขึ้น",
+      "manualPickPaywallTitle": "การเลือกไพ่ด้วยตนเองเป็นฟีเจอร์ของ Pro",
+      "manualPickPaywallDesc": "เลือกไพ่ใบใดก็ได้จากสำรับเต็ม อัปเกรดเป็น Pro เพื่อปลดล็อก — ชำระเงินผ่าน Stripe ในหน้าต่อไป",
+      "manualPickPaywallFeature": "เลือกไพ่ด้วยตนเองจากสำรับเต็ม",
+      "manualPickPaywallInsufficient": "ไม่รวมในแพ็กเกจ Basic",
+      "manualPickPaywallNote": "เลือกแพ็กเกจเพื่อไปยังหน้าชำระเงิน Stripe ที่ปลอดภัย"
     },
     "editQuestion": {
       "title": "แก้ไขคำถามของคุณ",


### PR DESCRIPTION
## Summary
Implement subscription tier-based feature gating for tarot card draws, including a new paywall dialog component and plan-specific limits on card selection and manual card picking.

## Key Changes

- **New PaywallDialog component** (`components/subscription/paywall-dialog.tsx`): A reusable modal that displays subscription plans with pricing, features, and upgrade options. Supports monthly/annual billing cycles, currency localization, and tier-based feature availability.

- **Plan limits system** (`lib/payments/plan-limits.ts`): New utility functions to enforce subscription tier restrictions:
  - Free tier: maximum 3 cards per draw
  - Paid tiers (Basic/Pro): maximum 10 cards per draw
  - Manual card picking restricted to Basic and Pro tiers

- **DrawCardSection gating** (`components/chat/draw-card-section.tsx`):
  - Manual card selection now shows paywall when user is on free tier
  - Card count increment button shows lock icon and triggers paywall when at tier limit
  - Added hint text explaining free tier card limits
  - Integrated PaywallDialog for manual pick and card count upgrades

- **ChatSession plan enforcement** (`components/chat/session.tsx`):
  - Card count clamped to tier limits in useMemo hooks
  - Spread type automatically downgraded if it exceeds tier limits (e.g., "detailed" → "general" for free tier)
  - Plan tier passed to API and DrawCardSection component
  - Card count change handler respects tier maximums

- **API decision prompt** (`app/api/chat/route.ts`):
  - Added plan tier parameter to chat decision prompt
  - LLM instructed to respect free tier 3-card limit and avoid suggesting larger spreads for free users

- **Localization**: Added paywall-related strings in English, Thai, and Lao translations covering:
  - Free tier card limit hints
  - Manual pick paywall title, description, and feature text
  - Upgrade prompts and checkout notes

## Implementation Details

- Paywall dialog displays all subscription plans with current tier highlighting and "Current plan" labels
- Disabled plan cards show lock icons for features not available at that tier
- Annual billing shows calculated monthly price and discount percentage
- Card selection respects both user's current tier and absolute maximum (10 cards)
- Spread type downgrade logic ensures free tier users get valid spreads even if AI suggests larger ones

https://claude.ai/code/session_017UVu8sayyaR7g9w51UmEny