### PR TITLE
Keep reasoning text inside expanded thought

### DIFF
--- a/components/chat/dynamic-thinking.tsx
+++ b/components/chat/dynamic-thinking.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { Check, ChevronDown, ChevronRight, Loader2 } from "lucide-react"
 
 export interface DynamicThinkingLabels {
@@ -17,8 +17,103 @@ export interface DynamicThinkingLabels {
 const DEFAULT_LABELS: DynamicThinkingLabels = {
     consulting: "Consulting…",
     active: "Chain of thoughts",
-    complete: "Consultation Complete",
+    complete: "Deep consult for {seconds} sec",
     toggle: "Toggle reasoning",
+}
+
+const MAX_HEADLINE_WORDS = 5
+
+const LEADING_FILLER_PATTERN =
+    /^(?:i\s+(?:need|want|have)\s+to|i(?:'|\u2019)ll|i\s+will|i(?:'|\u2019)m\s+going\s+to|i\s+am\s+going\s+to|i\s+should|let(?:'|\u2019)s|let\s+me|now\s+i(?:'|\u2019)ll|now\s+i\s+will|next\s+i(?:'|\u2019)ll|next\s+i\s+will|then\s+i(?:'|\u2019)ll|then\s+i\s+will|this\s+will|it(?:'|\u2019)s\s+essential\s+for\s+me\s+to)\s+/i
+
+const ENGLISH_STOP_WORDS = new Set([
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "be",
+    "for",
+    "in",
+    "is",
+    "it",
+    "of",
+    "or",
+    "so",
+    "that",
+    "the",
+    "to",
+    "with",
+])
+
+function titleCaseAscii(phrase: string): string {
+    return phrase.replace(/\b[a-z]/g, (char) => char.toUpperCase())
+}
+
+function compactWords(segment: string): string {
+    const words = segment
+        .replace(/[`*_#>[\](){}]/g, " ")
+        .replace(/[,:;]+/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .split(" ")
+        .filter(Boolean)
+
+    const usefulWords = words.filter(
+        (word) => !ENGLISH_STOP_WORDS.has(word.toLowerCase()),
+    )
+    const headlineWords = (usefulWords.length >= 2 ? usefulWords : words).slice(
+        0,
+        MAX_HEADLINE_WORDS,
+    )
+
+    return headlineWords.join(" ")
+}
+
+function deriveHeadline(reasoning: string, fallback: string): string {
+    const normalized = reasoning.replace(/\s+/g, " ").trim()
+    if (!normalized) return fallback
+
+    const segments = normalized
+        .split(/(?<=[.!?。！？…])\s+|\n+/)
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length >= 8)
+
+    const latestSegment = segments[segments.length - 1] ?? normalized
+    const recentText = (segments.length ? segments : [normalized])
+        .slice(-3)
+        .join(" ")
+        .toLowerCase()
+
+    if (
+        /repo|repository/.test(recentText) &&
+        /option|approach|path/.test(recentText)
+    ) {
+        return "Exploring repository options"
+    }
+    if (/repo|repository/.test(recentText)) return "Exploring repository"
+    if (/option|approach|path/.test(recentText)) return "Exploring options"
+    if (/tool|glob|rg|search/.test(recentText)) return "Choosing search tools"
+    if (/file|component|code/.test(recentText)) return "Inspecting code"
+    if (/implement|update|change|edit/.test(recentText)) return "Planning updates"
+    if (/test|lint|verify|check/.test(recentText)) return "Verifying changes"
+    if (/question|intent|request/.test(recentText)) return "Reading the question"
+
+    const cleaned = latestSegment
+        .replace(LEADING_FILLER_PATTERN, "")
+        .replace(/^(?:because|so|then|next|now)\s+/i, "")
+        .trim()
+    const compacted = compactWords(cleaned)
+    if (!compacted) return fallback
+
+    return /^[\x00-\x7F]+$/.test(compacted)
+        ? titleCaseAscii(compacted)
+        : compacted
+}
+
+function formatCompleteLabel(template: string, seconds: number | null): string {
+    if (!template.includes("{seconds}")) return template
+    return template.replace("{seconds}", String(seconds ?? 1))
 }
 
 /**
@@ -26,8 +121,8 @@ const DEFAULT_LABELS: DynamicThinkingLabels = {
  *
  * States:
  *   1. Initial wait      — `isThinking` and no reasoning yet → "Consulting…".
- *   2. Streaming reasoning — `isThinking` with reasoning → stable label + chevron.
- *   4. Complete          — `!isThinking` with reasoning → checkmark + complete label.
+ *   2. Streaming reasoning — `isThinking` with reasoning → short dynamic headline + chevron.
+ *   4. Complete          — `!isThinking` with reasoning → checkmark + elapsed time.
  * (Renders nothing once finished if no reasoning was ever produced.)
  *
  * Fully controlled: it keeps no streaming buffers of its own (the parent owns
@@ -47,9 +142,27 @@ export function DynamicThinking({
 }) {
     const resolvedLabels = { ...DEFAULT_LABELS, ...labels }
     const [expanded, setExpanded] = useState(false)
+    const [completedSeconds, setCompletedSeconds] = useState<number | null>(
+        null,
+    )
     const scrollRef = useRef<HTMLDivElement | null>(null)
+    const startedAtRef = useRef<number | null>(null)
 
     const hasReasoning = reasoningText.trim().length > 0
+    const activeHeadline = useMemo(
+        () =>
+            hasReasoning
+                ? deriveHeadline(reasoningText, resolvedLabels.active)
+                : resolvedLabels.consulting,
+        [
+            hasReasoning,
+            reasoningText,
+            resolvedLabels.active,
+            resolvedLabels.consulting,
+        ],
+    )
+    const [animatedHeadline, setAnimatedHeadline] = useState(activeHeadline)
+    const [headlineVersion, setHeadlineVersion] = useState(0)
 
     // Keep the expanded transcript pinned to the latest tokens while streaming.
     useEffect(() => {
@@ -57,6 +170,34 @@ export function DynamicThinking({
         const el = scrollRef.current
         if (el) el.scrollTop = el.scrollHeight
     }, [reasoningText, expanded, isThinking])
+
+    useEffect(() => {
+        if (isThinking) {
+            if (startedAtRef.current === null) {
+                startedAtRef.current = performance.now()
+                setCompletedSeconds(null)
+            }
+            return
+        }
+
+        if (hasReasoning && startedAtRef.current !== null) {
+            const elapsedMs = performance.now() - startedAtRef.current
+            setCompletedSeconds(Math.max(1, Math.round(elapsedMs / 1000)))
+            startedAtRef.current = null
+        }
+    }, [hasReasoning, isThinking])
+
+    useEffect(() => {
+        if (animatedHeadline === activeHeadline) return
+
+        const delayMs = isThinking && hasReasoning ? 180 : 0
+        const timeout = window.setTimeout(() => {
+            setAnimatedHeadline(activeHeadline)
+            setHeadlineVersion((version) => version + 1)
+        }, delayMs)
+
+        return () => window.clearTimeout(timeout)
+    }, [activeHeadline, animatedHeadline, hasReasoning, isThinking])
 
     // Nothing meaningful happened (no reasoning, not thinking) — let the answer
     // speak for itself.
@@ -66,8 +207,8 @@ export function DynamicThinking({
         isThinking && !hasReasoning
             ? resolvedLabels.consulting
             : !isThinking
-              ? resolvedLabels.complete
-              : resolvedLabels.active
+              ? formatCompleteLabel(resolvedLabels.complete, completedSeconds)
+              : animatedHeadline
 
     const canExpand = hasReasoning
 
@@ -87,7 +228,8 @@ export function DynamicThinking({
                 )}
 
                 <span
-                    className='min-w-0 max-w-[16rem] truncate text-sm font-medium text-white/90 sm:max-w-[26rem]'
+                    key={headlineVersion}
+                    className='min-w-0 max-w-[16rem] truncate text-sm font-medium text-white/90 animate-fade-swap sm:max-w-[26rem]'
                     title={headlineText}
                 >
                     {headlineText}

--- a/components/chat/dynamic-thinking.tsx
+++ b/components/chat/dynamic-thinking.tsx
@@ -1,11 +1,13 @@
 "use client"
 
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Check, ChevronDown, ChevronRight, Loader2 } from "lucide-react"
 
 export interface DynamicThinkingLabels {
     /** Shown before any reasoning tokens arrive (State 1). */
     consulting: string
+    /** Shown while reasoning tokens are streaming (State 2). */
+    active: string
     /** Shown once reasoning finishes and the answer begins (State 4). */
     complete: string
     /** Accessible label for the expand/collapse control. */
@@ -14,20 +16,9 @@ export interface DynamicThinkingLabels {
 
 const DEFAULT_LABELS: DynamicThinkingLabels = {
     consulting: "Consulting…",
+    active: "Chain of thoughts",
     complete: "Consultation Complete",
     toggle: "Toggle reasoning",
-}
-
-/**
- * Collapse runs of whitespace and return the most recent sentence-like segment
- * of the reasoning so the headline tracks the model's *current* train of
- * thought instead of the whole transcript.
- */
-function deriveHeadline(reasoning: string): string {
-    const normalized = reasoning.replace(/\s+/g, " ").trim()
-    if (!normalized) return ""
-    const segments = normalized.split(/(?<=[.!?。！？…])\s+/).filter(Boolean)
-    return segments.length ? segments[segments.length - 1] : normalized
 }
 
 /**
@@ -35,13 +26,13 @@ function deriveHeadline(reasoning: string): string {
  *
  * States:
  *   1. Initial wait      — `isThinking` and no reasoning yet → "Consulting…".
- *   2. Streaming reasoning — `isThinking` with reasoning → live headline + chevron.
+ *   2. Streaming reasoning — `isThinking` with reasoning → stable label + chevron.
  *   4. Complete          — `!isThinking` with reasoning → checkmark + complete label.
  * (Renders nothing once finished if no reasoning was ever produced.)
  *
  * Fully controlled: it keeps no streaming buffers of its own (the parent owns
- * `reasoningText`), so there are no timers/intervals to leak. The only local
- * state is the expand/collapse toggle.
+ * `reasoningText`), and the transcript is only rendered inside the expanded
+ * panel. The only local state is the expand/collapse toggle.
  */
 export function DynamicThinking({
     reasoningText,
@@ -59,10 +50,6 @@ export function DynamicThinking({
     const scrollRef = useRef<HTMLDivElement | null>(null)
 
     const hasReasoning = reasoningText.trim().length > 0
-    const headline = useMemo(
-        () => deriveHeadline(reasoningText),
-        [reasoningText],
-    )
 
     // Keep the expanded transcript pinned to the latest tokens while streaming.
     useEffect(() => {
@@ -80,7 +67,7 @@ export function DynamicThinking({
             ? resolvedLabels.consulting
             : !isThinking
               ? resolvedLabels.complete
-              : headline || resolvedLabels.consulting
+              : resolvedLabels.active
 
     const canExpand = hasReasoning
 

--- a/components/chat/message-list.tsx
+++ b/components/chat/message-list.tsx
@@ -389,6 +389,7 @@ export default function MessageList({
     const thinkingLabels = useMemo(
         () => ({
             consulting: `${t("consulting")}…`,
+            active: t("thinkingActive"),
             complete: t("thinkingComplete"),
             toggle: t("thinkingToggle"),
         }),

--- a/components/chat/message-list.tsx
+++ b/components/chat/message-list.tsx
@@ -390,7 +390,7 @@ export default function MessageList({
         () => ({
             consulting: `${t("consulting")}…`,
             active: t("thinkingActive"),
-            complete: t("thinkingComplete"),
+            complete: t("thinkingCompleteTimed"),
             toggle: t("thinkingToggle"),
         }),
         [t],

--- a/messages/en.json
+++ b/messages/en.json
@@ -367,6 +367,7 @@
     "consulting": "Consulting",
     "thinkingActive": "Chain of thoughts",
     "thinkingComplete": "Consultation Complete",
+    "thinkingCompleteTimed": "Deep consult for {seconds} sec",
     "thinkingToggle": "Show reasoning",
     "enterBirthDate": "Please enter your birth date",
     "streamStopped": "Response stopped",

--- a/messages/en.json
+++ b/messages/en.json
@@ -365,6 +365,7 @@
     },
     "selectedCards": "You have selected {selectedCount}/{cardsToSelect} cards",
     "consulting": "Consulting",
+    "thinkingActive": "Chain of thoughts",
     "thinkingComplete": "Consultation Complete",
     "thinkingToggle": "Show reasoning",
     "enterBirthDate": "Please enter your birth date",

--- a/messages/lo.json
+++ b/messages/lo.json
@@ -377,6 +377,7 @@
     },
     "selectedCards": "ທ່ານເລືອກໄພ່ແລ້ວ {selectedCount}/{cardsToSelect} ໃບ",
     "consulting": "ກຳລັງປຶກສາ",
+    "thinkingActive": "ລຳດັບຄວາມຄິດ",
     "thinkingComplete": "ວິເຄາະສຳເລັດແລ້ວ",
     "thinkingToggle": "ສະແດງຂັ້ນຕອນການຄິດ",
     "enterBirthDate": "ກະລຸນາກອກວັນເກີດຂອງທ່ານ",

--- a/messages/lo.json
+++ b/messages/lo.json
@@ -379,6 +379,7 @@
     "consulting": "ກຳລັງປຶກສາ",
     "thinkingActive": "ລຳດັບຄວາມຄິດ",
     "thinkingComplete": "ວິເຄາະສຳເລັດແລ້ວ",
+    "thinkingCompleteTimed": "ປຶກສາເຊິ່ງເລິກ {seconds} ວິນາທີ",
     "thinkingToggle": "ສະແດງຂັ້ນຕອນການຄິດ",
     "enterBirthDate": "ກະລຸນາກອກວັນເກີດຂອງທ່ານ",
     "streamStopped": "ຢຸດຄຳຕອບໄວ້ແລ້ວ",

--- a/messages/th.json
+++ b/messages/th.json
@@ -378,6 +378,7 @@
     },
     "selectedCards": "คุณเลือกไพ่แล้ว {selectedCount}/{cardsToSelect} ใบ",
     "consulting": "กำลังปรึกษา",
+    "thinkingActive": "ลำดับความคิด",
     "thinkingComplete": "วิเคราะห์เสร็จสมบูรณ์",
     "thinkingToggle": "แสดงกระบวนการคิด",
     "enterBirthDate": "กรุณากรอกวันเกิดของคุณ",

--- a/messages/th.json
+++ b/messages/th.json
@@ -380,6 +380,7 @@
     "consulting": "กำลังปรึกษา",
     "thinkingActive": "ลำดับความคิด",
     "thinkingComplete": "วิเคราะห์เสร็จสมบูรณ์",
+    "thinkingCompleteTimed": "ปรึกษาเชิงลึก {seconds} วินาที",
     "thinkingToggle": "แสดงกระบวนการคิด",
     "enterBirthDate": "กรุณากรอกวันเกิดของคุณ",
     "streamStopped": "หยุดคำตอบไว้แล้ว",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Show a short, dynamic reasoning headline in the collapsed thought badge instead of the full streamed reasoning text
- Animate headline swaps with the existing fade-swap animation while reasoning streams
- Keep the full streamed reasoning transcript only inside the expanded thought panel
- Show a timed completed state: `Deep consult for {seconds} sec`
- Add the active/timed thinking labels to English, Thai, and Lao messages

## Testing
- `npx eslint components/chat/dynamic-thinking.tsx components/chat/message-list.tsx messages/en.json messages/th.json messages/lo.json` (passes with existing warning in `message-list.tsx`; JSON files are ignored by ESLint config)
- `npm run lint` (fails on pre-existing unrelated repo errors, e.g. `app/api/stars/add/route.ts`, `components/astrology/info-tab.tsx`, `components/beta-toaster.tsx`, `scripts/generate-meanings-json.js`, `test-chart-structure.js`, `types/google-ad-manager.d.ts`)
- `npx tsc --noEmit` (fails on pre-existing `.ts` extension import errors in `lib/astrology/__tests__`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89c24669-c785-4be4-a174-b9d14fbd4b07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89c24669-c785-4be4-a174-b9d14fbd4b07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

